### PR TITLE
Use <vaadin-grid-column-group> for action columns to prevent mixing them with data columns

### DIFF
--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../vaadin-grid/vaadin-grid.html">
 <link rel="import" href="../vaadin-grid/vaadin-grid-sorter.html">
+<link rel="import" href="../vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import" href="../vaadin-grid/vaadin-grid-tree-toggle.html">
 <link rel="import" href="../px-spinner/px-spinner.html">
 <link rel="import" href="../px-modal/px-modal.html">
@@ -170,23 +171,25 @@
         </px-data-grid-column>
       </template>
 
-      <template is="dom-if" if="[[_offerEditColumn(editable)]]" restamp>
-        <px-data-grid-edit-column
-          editted-item="[[_editingItem]]"
-          edit-mode="[[editable]]"
-          edit="[[_boundedEditItem]]"
-          cancel="[[_boundedCancelEdit]]">
-        </px-data-grid-column>
-      </template>
+      <vaadin-grid-column-group frozen>
+        <template is="dom-if" if="[[_offerEditColumn(editable)]]" restamp>
+          <px-data-grid-edit-column
+            editted-item="[[_editingItem]]"
+            edit-mode="[[editable]]"
+            edit="[[_boundedEditItem]]"
+            cancel="[[_boundedCancelEdit]]">
+          </px-data-grid-column>
+        </template>
 
-      <template is="dom-if" if="[[_offerActionColumn(editable, itemActions, _editingItem)]]" restamp>
-        <px-data-grid-action-column
-          item-actions="[[itemActions]]"
-          editted-item="[[_editingItem]]"
-          edit-mode="[[editable]]"
-          save="[[_boundedSaveItem]]">
-        </px-data-grid-column>
-      </template>
+        <template is="dom-if" if="[[_offerActionColumn(editable, itemActions, _editingItem)]]" restamp>
+          <px-data-grid-action-column
+            item-actions="[[itemActions]]"
+            editted-item="[[_editingItem]]"
+            edit-mode="[[editable]]"
+            save="[[_boundedSaveItem]]">
+          </px-data-grid-column>
+        </template>
+      </vaadin-grid-column-group>
     </vaadin-grid>
 
     <px-spinner size="40" hidden$="[[_spinnerHidden]]"></px-spinner>

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -222,7 +222,7 @@
   }
 
   function getHeaderCell(grid, index) {
-    return grid._vaadinGrid.$.header.querySelectorAll('[part~="cell"]')[index];
+    return grid._vaadinGrid.$.header.querySelectorAll('tr:nth-child(2) [part~="cell"]')[index];
   }
 
   function getHeaderCellContent(cell) {

--- a/test/items-without-ids.js
+++ b/test/items-without-ids.js
@@ -45,7 +45,7 @@ document.addEventListener('WebComponentsReady', () => {
       grid.selectionMode = 'multi';
       flushVaadinGrid(grid);
 
-      const selectAllCell = grid._vaadinGrid.$.header.querySelectorAll('[part~="header-cell"]')[0];
+      const selectAllCell = grid._vaadinGrid.$.header.querySelectorAll('tr:nth-child(2) [part~="header-cell"]')[0];
       const selectAllContent = selectAllCell.querySelector('slot').assignedNodes()[0];
       const selectAllElement = selectAllContent.querySelectorAll('px-data-grid-select-all')[0];
       const selectAllCheckBox = selectAllElement.shadowRoot.querySelectorAll('vaadin-checkbox')[0];


### PR DESCRIPTION
Now actions columns are wrapped into `<vaadin-grid-column-group frozen>` to prevent mixing them with other columns when doing reordering: 

![peek 2018-02-20 10-24](https://user-images.githubusercontent.com/6059356/36413734-58e58f0a-1628-11e8-9b09-6876b5bfe9f1.gif)

Notice, that users will be still able to reorder 2 action column. If that is not the desired behavior, let me know.