### PR TITLE
Fix for column header dropdown not opening

### DIFF
--- a/px-data-grid-header-cell.html
+++ b/px-data-grid-header-cell.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../px-dropdown/px-dropdown.html"/>
 <link rel="import" href="../px-icon-set/px-icon.html"/>
 <link rel="import" href="css/px-data-grid-header-cell-styles.html">
@@ -23,7 +24,7 @@
   </template>
   <script>
     {
-      class DataGridHeaderCellElement extends Polymer.Element {
+      class DataGridHeaderCellElement extends Polymer.GestureEventListeners(Polymer.Element) {
         static get is() {
           return 'px-data-grid-header-cell';
         }


### PR DESCRIPTION
Fix for column header dropdown not opening - needs tap/gesture support mixin addition.

Picking up latest px-dropdown, column header dropdown was not responding to tap event. Addition of gesture support mixin fixes this.