### PR TITLE
Add demo for px-data-grid-paginated

### DIFF
--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -53,7 +53,7 @@
     <!-- Header -->
     <px-demo-header
         module-name="px-data-grid"
-        description="The data grid displays tabular data with rich interactions to help users find, manage, and update important information. The px-data-grid component replaces the legacy px-data-table component and offers a wide range of new behaviors. The grid is complete rewrite with a new API and more features that targets Polymer 2+ runtime."
+        description="The data grid displays tabular data with rich interactions to help users find, manage, and update important information. The px-data-grid component replaces the legacy px-data-table component and offers a wide range of new behaviors. The grid is a complete rewrite with a new API and more features that targets Polymer 2+ runtime."
         github-org="predixdesignsystem"
         mobile desktop tablet>
     </px-demo-header>

--- a/demo/px-data-grid-paginated-demo.html
+++ b/demo/px-data-grid-paginated-demo.html
@@ -25,15 +25,36 @@
       .theme-switcher-checkbox input {
         margin-left: 5px;
       }
+
+      .button-row {
+        padding: 5px 0;
+      }
     </style>
     <custom-style>
-      <style include="px-demo-styles" is="custom-style"></style>
+      <style include="px-demo-styles" is="custom-style">
+        .beta-banner {
+          background-color: rgb(204, 85, 0); /* $status-orange4 */
+          padding: 1rem 5%;
+          color: white;
+          display: block;
+          width: 100%;
+        }
+
+        .beta-banner a {
+          color: white;
+        }
+      </style>
     </custom-style>
+
+    <div class="beta-banner">
+      px-data-grid is currently in beta. The docs and APIs might change. We don't recommend using it in production until the beta is finished. Please try the grid and give your feedback through <a href="https://github.com/predixdesignsystem/px-data-grid/issues">Github issues</a>.
+    </div>
 
     <!-- Header -->
     <px-demo-header
         module-name="px-data-grid-paginated"
-        description="The Data Grid component is useful for displaying tabular data, and provides more functionality than a simple table."
+        description="Paginated version of the data grid. The data grid displays tabular data with rich interactions to help users find, manage, and update important information. The px-data-grid component replaces the legacy px-data-table component and offers a wide range of new behaviors. The grid is complete rewrite with a new API and more features that targets Polymer 2+ runtime."
+        github-org="predixdesignsystem"
         mobile desktop tablet>
     </px-demo-header>
 
@@ -51,51 +72,28 @@
       <!-- Component ---------------------------------------------------------->
       <px-demo-component slot="px-demo-component">
         <px-data-grid-paginated
-            table-data="{{props.tableData.value}}"
-            auto-hide-page-list="{{props.autoHidePageList.value}}"
-            selection-mode="{{props.selectionMode.value}}"
-            selected-items="{{selectedItems}}"
-            hide-selection-column="{{props.hideSelectionColumn.value}}"
-            resizable="{{props.resizable.value}}"
-            striped="{{props.striped.value}}"
-            ellipsis="{{props.ellipsis.value}}"
-            multi-sort="{{props.multiSort.value}}"
-            column-reordering-allowed="{{props.columnReorderingAllowed.value}}"
-            hide-action-menu="{{props.hideActionMenu.value}}"
-            language="{{props.language.value}}"
-            auto-filter="{{props.autoFilter.value}}"
-            on-cell-hover="cellHoverListener"
-            on-cell-unhover="cellUnhoverListener"
-            selectable-page-sizes="{{props.selectablePageSizes.value}}"
             columns="{{props.columns.value}}"
-            grid-height="{{props.gridHeight.value}}"
-            table-actions="{{props.tableActions.value}}"
+            table-data="{{props.tableData.value}}"
+            striped="{{props.striped.value}}"
+            multi-sort="{{props.multiSort.value}}"
+            resizable="{{props.resizable.value}}"
             editable="{{props.editable.value}}"
             filterable="{{props.filterable.value}}"
+            auto-filter="{{props.autoFilter.value}}"
+            column-reordering-allowed="{{props.columnReorderingAllowed.value}}"
+            hide-selection-column="{{props.hideSelectionColumn.value}}"
+            selection-mode="{{props.selectionMode.value}}"
+            allow-sort-by-selection="{{props.allowSortBySelection.value}}"
+            hide-action-menu="{{props.hideActionMenu.value}}"
+            table-actions="{{props.tableActions.value}}"
+            item-actions="{{props.itemActions.value}}"
+            highlight="{{props.highlight.value}}"
+            selectable-page-sizes="{{props.selectablePageSizes.value}}"
+
             item-id-path="email"
-            on-table-action="tableActionListener">
+            selected-items="{{selectedItems}}"
+            on-table-action="handleTableAction">
         </px-data-grid-paginated>
-
-        <dom-if if="[[selectedItems.length]]">
-          <template>
-            Selected items:
-            <ul>
-              <template is="dom-repeat" items="{{selectedItems}}">
-                <li>[[_stringify(item)]]</li>
-              </template>
-            </ul>
-          </template>
-        </dom-if>
-
-        <label>
-          <input type="checkbox" checked="{{showHoveredCellData::change}}">
-          Show hovered cell data
-        </label>
-        <template is="dom-if" if="[[showHoveredCellData]]"><div>Hovered cell data: [[hoveredCellData]]</div></template>
-
-        <div>
-          <button type="button" on-click="_clearColumns">Reset Columns</button>
-        </div>
       </px-demo-component>
       <!-- END Component ------------------------------------------------------>
 
@@ -103,12 +101,16 @@
           slot="px-demo-component-snippet"
           element-properties="{{props}}"
           element-name="px-data-grid-paginated"
-          links-includes="[[linksIncludes]]">
+          codepen-link="https://glitch.com/edit/#!/px-data-grid-demo?path=README.md:29:215"
+          suppress-property-values='["tableData"]'>
       </px-demo-component-snippet>
     </px-demo-interactive>
 
     <!-- API Viewer -->
-    <px-demo-api-viewer source="px-data-grid-paginated" api-source-file-path="px-data-grid-paginated-api.json"></px-demo-api-viewer>
+    <px-demo-api-viewer
+        source="px-data-grid-paginated"
+        api-source-file-path="px-data-grid/px-data-grid-paginated-api.json">
+    </px-demo-api-viewer>
 
     <!-- Footer -->
     <px-demo-footer></px-demo-footer>
@@ -117,525 +119,732 @@
 
 </dom-module>
 <script>
-  Polymer({
-    is: 'px-data-grid-paginated-demo',
-
-    cellHoverListener: function(evt) {
-      this.hoveredCellData = evt.detail.cellContent;
-    },
-
-    cellUnhoverListener: function(evt) {
-      if (this.hoveredCellData === evt.detail.cellContent) {
-        this.hoveredCellData = '';
-      }
-    },
-
-    properties: {
-      showHoveredCellData: {
-        type: Boolean,
-        value: false,
-      },
-
-      hoveredCellData: {
-        type: String
-      },
-      /**
-       * Note: The actual data/values for `props` are placed in `this.demoProps`
-       * to create a static reference that Polymer shouldn't overwrite.
-       *
-       * On object containing all the properties the user can configure for this
-       * demo. Usually a pretty similar copy of the component's `properties` block
-       * with some additional sugar added to describe what kind of input the
-       * user will be shown and how that input should be configured.
-       *
-       * Note that `value` for each property is the default that will be set
-       * unless a config from `configs` is applied by default.
-       *
-       * @property props
-       * @type {Object}
-       */
-      props: {
-        type: Object,
-        value: function() {
-          return this.demoProps;
-        }
-      },
-
-      /**
-       * An array of pre-configured `props` that can be used to provide the user
-       * with a set of common examples. These configs will be made available
-       * as a set of tabs the user can click that will automatically change
-       * the `props` to specific values.
-       *
-       * @example
-       *
-       * Each config is an object. Its keys should be the names of the configurable
-       * properties defined in your `demoProps` above. Each key's value should
-       * be the new prop value for the configuration. You can also include these
-       * optional keys:
-       *
-       * - `configName` - a String value that will be used for the title of the tab
-       * - `configReset` - a Boolean, if `true` resets all props. Defaults to `false`.
-       *
-       * @property configs
-       * @type {Array}
-       */
-      configs: {
-        type: Array,
-        value: function() {
-          return [
-            {
-              configName: 'Default',
-              configReset: true,
-            },
-            {
-              configName: 'More rows (250 generated)',
-              configReset: true,
-              tableData: this._generateData(250)
-            }
-          ];
-        }
-      },
-
-      selectedItems: {
-        type: Array,
-      }
-    },
-    /**
-     * A reference for `this.props`. Read the documentation there.
+  {
+    /* *************************************************************************
+     * DEMO DATA
      */
-    demoProps: {
-      tableData: {
-        type: Object,
-        defaultValue: [
-          {
-            first: 'Elizabeth',
-            last: 'Wong',
-            email: 'sika@iknulber.cl'
-          },
-          {
-            first: 'Jeffrey',
-            last: 'Hamilton',
-            email: 'cofok@rac.be'
-          },
-          {
-            first: 'Alma',
-            last: 'Martin',
-            email: 'dotta@behtam.la'
-          },
-          {
-            first: 'Carl',
-            last: 'Saunders',
-            email: 'seh@bibapu.gy'
-          },
-          {
-            first: 'Willie',
-            last: 'Dennis',
-            email: 'izko@dahokwej.ci'
-          },
-          {
-            first: 'Angel',
-            last: 'Lewis',
-            email: 'ma@et.nz'
-          },
-          {
-            first: 'Jessie',
-            last: 'Sherman',
-            email: 'hunocnas@mosuraj.gi'
-          },
-          {
-            first: 'Eric',
-            last: 'Brewer',
-            email: 'tu@coajoul.de'
-          },
-          {
-            first: 'Cory',
-            last: 'Ramos',
-            email: 'kilamja@oviafbek.ss'
-          },
-          {
-            first: 'Bertie',
-            last: 'Ross',
-            email: 'ifuvu@getvi.my'
-          },
-          {
-            first: 'Oscar',
-            last: 'Estrada',
-            email: 'minu@kerireg.gp'
-          },
-          {
-            first: 'Estelle',
-            last: 'Patton',
-            email: 'hudliami@lijihen.fi'
-          },
-          {
-            first: 'Sallie',
-            last: 'George',
-            email: 'wo@zof.bf'
-          },
-          {
-            first: 'Harriett',
-            last: 'Wheeler',
-            email: 'woguw@cibevo.pt'
-          },
-          {
-            first: 'Bryan',
-            last: 'Houston',
-            email: 'tekkubom@gaahu.ge'
-          },
-          {
-            first: 'Leon',
-            last: 'Craig',
-            email: 'wo@gurozo.gs'
-          },
-          {
-            first: 'Mable',
-            last: 'Taylor',
-            email: 'um@fegnocka.pg'
-          },
-          {
-            first: 'Ida',
-            last: 'Hansen',
-            email: 'lufahu@gewlaskoc.kh'
-          },
-          {
-            first: 'Adele',
-            last: 'Thornton',
-            email: 'gugugo@nevigi.th'
-          },
-          {
-            first: 'Jerry',
-            last: 'Kelley',
-            email: 'solef@zoose.as'
-          },
-          {
-            first: 'Clara',
-            last: 'Delgado',
-            email: 'fivticnuf@upkib.rw'
-          },
-          {
-            first: 'Joseph',
-            last: 'Stevenson',
-            email: 'be@viijo.lk'
-          },
-          {
-            first: 'Ellen',
-            last: 'Perry',
-            email: 'ce@jewo.sv'
-          },
-          {
-            first: 'Ronnie',
-            last: 'Cummings',
-            email: 'iro@wi.vn'
-          },
-          {
-            first: 'Olive',
-            last: 'Santos',
-            email: 'vo@nees.cn'
-          },
-          {
-            first: 'Rena',
-            last: 'Tucker',
-            email: 'uharoc@lohpol.gl'
-          },
-          {
-            first: 'Nell',
-            last: 'Hicks',
-            email: 'felaf@vo.sb'
-          },
-          {
-            first: 'Jesus',
-            last: 'Hawkins',
-            email: 'wahgab@mu.mk'
-          },
-          {
-            first: 'Duane',
-            last: 'Harris',
-            email: 'kellanjob@daava.ph'
-          },
-          {
-            first: 'Jonathan',
-            last: 'Holmes',
-            email: 'jir@bikuf.dj'
-          },
-          {
-            first: 'Christine',
-            last: 'Collier',
-            email: 'bocago@jerla.ba'
-          },
-          {
-            first: 'Brandon',
-            last: 'Thompson',
-            email: 'regoh@ji.kn'
-          },
-          {
-            first: 'Anne',
-            last: 'Dunn',
-            email: 'samhof@are.sc'
-          },
-          {
-            first: 'Viola',
-            last: 'Sherman',
-            email: 'wep@kezori.lt'
-          },
-          {
-            first: 'Kathryn',
-            last: 'Harper',
-            email: 'keotoci@je.mr'
-          },
-          {
-            first: 'Calvin',
-            last: 'Bates',
-            email: 'bomeg@lip.bw'
-          },
-          {
-            first: 'Maggie',
-            last: 'Collins',
-            email: 'zonefto@ihihij.ke'
-          },
-          {
-            first: 'Zachary',
-            last: 'Mitchell',
-            email: 'wamez@cilvahbod.mk'
-          },
-          {
-            first: 'Raymond',
-            last: 'Kelley',
-            email: 'wuz@napujos.tt'
-          },
-          {
-            first: 'Augusta',
-            last: 'Torres',
-            email: 'bum@ne.lt'
-          },
-          {
-            first: 'Charlie',
-            last: 'Lindsey',
-            email: 'ruhlu@tuobujen.ao'
-          },
-          {
-            first: 'Jeremy',
-            last: 'Swanson',
-            email: 'ed@ted.km'
-          },
-          {
-            first: 'Joel',
-            last: 'Gonzalez',
-            email: 'ej@pot.bz'
-          },
-          {
-            first: 'Lillie',
-            last: 'Hawkins',
-            email: 'uguiv@mudbuve.pa'
-          },
-          {
-            first: 'Joel',
-            last: 'Watts',
-            email: 'naafe@oli.bb'
-          },
-          {
-            first: 'Isabella',
-            last: 'Sandoval',
-            email: 'asobu@wedef.af'
-          },
-          {
-            first: 'Roy',
-            last: 'Lyons',
-            email: 'rasaogu@tadiri.tc'
-          }
-        ],
-        inputType: 'code:JSON'
-      },
 
-      selectionMode: {
-        type: String,
-        value: 'none',
-        inputType: 'dropdown',
-        inputChoices: ['none', 'single', 'multi']
+    const demoTableDataNamesSmall = [
+      {
+        first: 'Elizabeth',
+        last: 'Wong',
+        email: 'sika@iknulber.cl',
+        born: '1995-04-12',
+        age: 23
       },
-
-      filterable: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      {
+        first: 'Jeffrey',
+        last: 'Wong',
+        email: 'cofok@rac.be',
+        born: '1985-04-12',
+        age: 32
       },
-
-      autoHidePageList: {
-        type: Boolean,
-        defaultValue: true,
-        inputType: 'toggle'
+      {
+        first: 'Alma',
+        last: 'Martin',
+        email: 'dotta@behtam.la',
+        born: '1973-04-12',
+        age: 44
       },
-
-      hideSelectionColumn: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      {
+        first: 'Carl',
+        last: 'Saunders',
+        email: 'seh@bibapu.gy',
+        born: '2002-04-12',
+        age: 12
       },
-
-      multiSort: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      columnReorderingAllowed: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      hideActionMenu: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      autoFilter: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      resizable: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      gridHeight: {
-        type: String,
-        defaultValue: 'default',
-        inputType: 'dropdown',
-        inputChoices: ['default', 'auto', '300px', '600px', '900px']
-      },
-
-      striped: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      ellipsis: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      editable: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
-      },
-
-      selectablePageSizes: {
-        type: Array,
-        value: [10, 20, 30],
-        inputType: 'code:JSON'
-      },
-
-      language: {
-        type: String,
-        value: 'en',
-        inputType: 'dropdown',
-        inputChoices: ['en', 'fr', 'fi']
-      },
-
-      columns: {
-        type: Array,
-        value: [
-          {
-            path: 'first',
-            name: 'First Name',
-            editable: true,
-            required: true,
-            renderer: 'px-data-grid-string-renderer'
-          },
-          {
-            path: 'last',
-            name: 'Last Name'
-          },
-          {
-            path: 'email',
-            name: 'Email'
-          }
-        ],
-        inputType: 'code:JSON'
-      },
-
-      tableActions: {
-        type: Object,
-        defaultValue: [
-          {
-            name: 'Export CSV',
-            id: 'CSV'
-          }
-        ],
-        inputType: 'code:JSON',
-        _visibleForConfig: false
+      {
+        first: 'Willie',
+        last: 'Dennis',
+        email: 'izko@dahokwej.ci',
+        born: '1930-04-12',
+        age: 88
       }
-    },
+    ];
 
-    _stringify: function(item) {
-      return JSON.stringify(item);
-    },
+    const demoTableDataNamesLarge = [
+      {
+        first: 'Elizabeth',
+        last: 'Wong',
+        full: 'Elizabeth Wong',
+        email: 'sika@iknulber.cl',
+        born: '1985-04-12',
+        age: 32
+      },
+      {
+        first: 'Jeffrey',
+        last: 'Hamilton',
+        email: 'cofok@rac.be',
+        born: '1995-04-12',
+        age: 23
+      },
+      {
+        first: 'Alma',
+        last: 'Martin',
+        email: 'dotta@behtam.la',
+        born: '1975-04-12',
+        age: 42
+      },
+      {
+        first: 'Carl',
+        last: 'Saunders',
+        email: 'seh@bibapu.gy',
+        born: '2002-04-12',
+        age: 12
+      },
+      {
+        first: 'Willie',
+        last: 'Dennis',
+        email: 'izko@dahokwej.ci',
+        born: '1973-04-12',
+        age: 44
+      },
+      {
+        first: 'Angel',
+        last: 'Lewis',
+        email: 'ma@et.nz',
+        born: '1932-04-12',
+        age: 89
+      },
+      {
+        first: 'Jessie',
+        last: 'Sherman',
+        email: 'hunocnas@mosuraj.gi',
+        born: '1990-04-12',
+        age: 27
+      },
+      {
+        first: 'Eric',
+        last: 'Brewer',
+        email: 'tu@coajoul.de',
+        born: '1930-04-12',
+        age: 88
+      },
+      {
+        first: 'Cory',
+        last: 'Ramos',
+        email: 'kilamja@oviafbek.ss',
+        born: '2006-04-12',
+        age: 9
+      },
+      {
+        first: 'Bertie',
+        last: 'Ross',
+        email: 'ifuvu@getvi.my',
+        born: '1990-04-12',
+        age: 27
+      },
+      {
+        first: 'Oscar',
+        last: 'Estrada',
+        email: 'minu@kerireg.gp',
+        born: '2002-04-12',
+        age: 15
+      },
+      {
+        first: 'Estelle',
+        last: 'Patton',
+        email: 'hudliami@lijihen.fi',
+        born: '2006-04-12',
+        age: 11
+      },
+      {
+        first: 'Sallie',
+        last: 'George',
+        email: 'wo@zof.bf',
+        born: '1985-04-12',
+        age: 33
+      },
+      {
+        first: 'Harriett',
+        last: 'Wheeler',
+        email: 'woguw@cibevo.pt',
+        born: '1968-04-12',
+        age: 52
+      },
+      {
+        first: 'Bryan',
+        last: 'Houston',
+        email: 'tekkubom@gaahu.ge',
+        born: '1940-04-12',
+        age: 77
+      },
+      {
+        first: 'Leon',
+        last: 'Craig',
+        email: 'wo@gurozo.gs',
+        born: '2015-04-12',
+        age: 2
+      },
+      {
+        first: 'Mable',
+        last: 'Taylor',
+        email: 'um@fegnocka.pg',
+        born: '2006-04-12',
+        age: 11
+      },
+      {
+        first: 'Ida',
+        last: 'Hansen',
+        email: 'lufahu@gewlaskoc.kh',
+        born: '1973-04-12',
+        age: 44
+      },
+      {
+        first: 'Adele',
+        last: 'Thornton',
+        email: 'gugugo@nevigi.th',
+        born: '1973-04-12',
+        age: 41
+      },
+      {
+        first: 'Jerry',
+        last: 'Kelley',
+        email: 'solef@zoose.as',
+        born: '1950-04-12',
+        age: 67
+      },
+      {
+        first: 'Clara',
+        last: 'Delgado',
+        email: 'fivticnuf@upkib.rw',
+        born: '1951-04-12',
+        age: 66
+      },
+      {
+        first: 'Joseph',
+        last: 'Stevenson',
+        email: 'be@viijo.lk',
+        born: '1995-04-12',
+        age: 22
+      },
+      {
+        first: 'Ellen',
+        last: 'Perry',
+        email: 'ce@jewo.sv',
+        born: '1996-04-12',
+        age: 23
+      },
+      {
+        first: 'Ronnie',
+        last: 'Cummings',
+        email: 'iro@wi.vn',
+        born: '2000-04-12',
+        age: 17
+      },
+      {
+        first: 'Olive',
+        last: 'Santos',
+        email: 'vo@nees.cn',
+        born: '1918-04-12',
+        age: 99
+      },
+      {
+        first: 'Rena',
+        last: 'Tucker',
+        email: 'uharoc@lohpol.gl',
+        born: '1915-04-12',
+        age: 102
+      },
+      {
+        first: 'Nell',
+        last: 'Hicks',
+        email: 'felaf@vo.sb',
+        born: '1940-04-12',
+        age: 76
+      },
+      {
+        first: 'Jesus',
+        last: 'Hawkins',
+        email: 'wahgab@mu.mk',
+        born: '1983-04-12',
+        age: 34
+      },
+      {
+        first: 'Duane',
+        last: 'Harris',
+        email: 'kellanjob@daava.ph',
+        born: '1996-04-12',
+        age: 23
+      },
+      {
+        first: 'Jonathan',
+        last: 'Holmes',
+        email: 'jir@bikuf.dj',
+        born: '1969-04-12',
+        age: 49
+      },
+      {
+        first: 'Christine',
+        last: 'Collier',
+        email: 'bocago@jerla.ba',
+        born: '1970-04-12',
+        age: 48
+      },
+      {
+        first: 'Brandon',
+        last: 'Thompson',
+        email: 'regoh@ji.kn',
+        born: '1973-04-12',
+        age: 43
+      },
+      {
+        first: 'Anne',
+        last: 'Dunn',
+        email: 'samhof@are.sc',
+        born: '1976-04-12',
+        age: 41
+      },
+      {
+        first: 'Viola',
+        last: 'Sherman',
+        email: 'wep@kezori.lt',
+        born: '1973-04-12',
+        age: 44
+      },
+      {
+        first: 'Kathryn',
+        last: 'Harper',
+        email: 'keotoci@je.mr',
+        born: '1941-04-12',
+        age: 77
+      },
+      {
+        first: 'Calvin',
+        last: 'Bates',
+        email: 'bomeg@lip.bw',
+        born: '1979-04-12',
+        age: 38
+      },
+      {
+        first: 'Maggie',
+        last: 'Collins',
+        email: 'zonefto@ihihij.ke',
+        born: '1982-04-12',
+        age: 35
+      },
+      {
+        first: 'Zachary',
+        last: 'Mitchell',
+        email: 'wamez@cilvahbod.mk',
+        born: '1993-04-12',
+        age: 26
+      },
+      {
+        first: 'Raymond',
+        last: 'Kelley',
+        email: 'wuz@napujos.tt',
+        born: '1995-04-12',
+        age: 21
+      },
+      {
+        first: 'Augusta',
+        last: 'Torres',
+        email: 'bum@ne.lt',
+        born: '1967-04-12',
+        age: 54
+      },
+      {
+        first: 'Charlie',
+        last: 'Lindsey',
+        email: 'ruhlu@tuobujen.ao',
+        born: '2002-04-12',
+        age: 15
+      },
+      {
+        first: 'Jeremy',
+        last: 'Swanson',
+        email: 'ed@ted.km',
+        born: '1997-04-12',
+        age: 21
+      },
+      {
+        first: 'Joel',
+        last: 'Gonzalez',
+        email: 'ej@pot.bz',
+        born: '1999-04-12',
+        age: 18
+      },
+      {
+        first: 'Lillie',
+        last: 'Hawkins',
+        email: 'uguiv@mudbuve.pa',
+        born: '1975-04-12',
+        age: 43
+      },
+      {
+        first: 'Joel',
+        last: 'Watts',
+        email: 'naafe@oli.bb',
+        born: '2017-04-12',
+        age: 1
+      },
+      {
+        first: 'Isabella',
+        last: 'Sandoval',
+        email: 'asobu@wedef.af',
+        born: '2016-04-12',
+        age: 3
+      },
+      {
+        first: 'Roy',
+        last: 'Lyons',
+        email: 'rasaogu@tadiri.tc',
+        born: '1924-04-12',
+        age: 88
+      }
+    ];
 
-    _getDefaultColumns() {
-      return [
-        {
-          path: 'first',
-          name: 'First Name'
-        },
-        {
-          path: 'last',
-          name: 'Last Name'
-        },
-        {
-          path: 'email',
-          name: 'Email'
+    /* Basic column definition for names demo data, editable fields with strings */
+    const demoColumnsSimple = [
+      {
+        name: 'First Name',
+        path: 'first',
+        renderer: 'px-data-grid-string-renderer',
+        editable: true
+      },
+      {
+        name: 'Last Name',
+        path: 'last',
+        renderer: 'px-data-grid-string-renderer',
+        editable: true
+      },
+      {
+        name: 'Email',
+        path: 'email'
+      }
+    ];
+
+    /* Extended column defintion to show more columns with additional types */
+    const demoColumnsMoreTypes = [
+      ...demoColumnsSimple,
+      {
+        name: 'Age',
+        path: 'age',
+        renderer: 'px-data-grid-number-renderer',
+        editable: true,
+        type: 'number'
+      },
+      {
+        name: 'Birth Date',
+        path: 'born',
+        renderer: 'px-data-grid-date-renderer',
+        editable: true,
+        type: 'date'
+      }
+    ];
+
+
+    /* Highlight rules for the "Highlight rules" config */
+    const demoHighlight = [
+      {
+        type: 'cell',
+        color: 'lightgreen',
+        condition: (cellContent, column, item) => {
+          return cellContent == 'Dennis';
         }
-      ];
-    },
+      },
+      {
+        type: 'column',
+        color: 'lightskyblue',
+        condition: (column, item) => {
+          return column.path == 'last';
+        }
+      },
+      {
+        type: 'row',
+        color: 'lightsalmon',
+        condition: (cellContent, item) => {
+          return item && (item.last == 'Dennis' || item.first == 'Carl');
+        }
+      }
+    ];
 
-    _clearColumns(event) {
-      this.props.columns.value = this._getDefaultColumns();
-    },
+    /* *************************************************************************
+     * DEMO PROPS
+     */
 
-    _generateData(amount) {
-      const data = [];
-      for (let i = 0; i < amount; ++i) {
-        data.push({
-          first: 'First ' + (i + 1),
-          last: 'Last ' + (i + 1),
-          email: 'user' + (i + 1) + '@example.com'
+    const tableData = {
+      type: Object,
+      inputType: 'code:JSON',
+      defaultValue: demoTableDataNamesSmall
+    };
+
+    const columns = {
+      type: Object,
+      inputType: 'code:JSON',
+      defaultValue: demoColumnsSimple
+    };
+
+    const striped = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const multiSort = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const editable = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const resizable = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const filterable = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false,
+      // @TODO: Fix px-demo to allow a prop to be hidden for default config,
+      // this is required to hide a property on first page load.
+      _visibleForConfig: false
+    };
+
+    const autoFilter = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const columnReorderingAllowed = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const hideSelectionColumn = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const allowSortBySelection = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const selectionMode = {
+      type: String,
+      inputType: 'dropdown',
+      inputChoices: ['none', 'single', 'multi'],
+      defaultValue: 'none',
+      // @TODO: Figure out why px-demo initially sets selectionMode to something
+      // other than 'none'. Setting the value here will only take effect when
+      // the demo is initialized, and is overridden later.
+      value: 'none'
+    };
+
+    const hideActionMenu = {
+      type: Boolean,
+      inputType: 'toggle',
+      defaultValue: false
+    };
+
+    const tableActions = {
+      type: Object,
+      inputType: 'code:JSON',
+      defaultValue: [
+        {
+          name: 'Export CSV',
+          id: 'CSV'
+        }
+      ]
+    };
+
+    const itemActions = {
+      type: Object,
+      inputType: 'code:JSON',
+      defaultValue: [
+        {
+          name: 'Add Row',
+          id: 'add'
+        },
+        {
+          name: 'Delete Row',
+          id: 'delete'
+        }
+      ]
+    };
+
+    const highlight = {
+      type: Array,
+      inputType: 'code:EvaluatedJavaScript',
+      defaultValue: [],
+      // @TODO: Figure out why px-demo initially sets highlight to something
+      // other than the default value. Setting the value here will only
+      // take effect when the demo is initialized, and is overridden later.
+      value: [],
+      // @TODO: Fix px-demo to allow a prop to be hidden for default config,
+      // this is required to hide a property on first page load.
+      _visibleForConfig: false
+    };
+
+    const selectablePageSizes = {
+      type: Array,
+      inputType: 'code:JSON',
+      defaultValue: [10, 20, 30],
+      value: [10, 20, 30]
+    };
+
+    // @TODO: Decide if these configs should be added to additional demo config
+    // tabs to show more features.
+    //
+    // const gridHeight = {
+    //   type: String,
+    //   defaultValue: 'default',
+    //   inputType: 'dropdown',
+    //   inputChoices: ['default', 'auto', '300px', '600px', '900px']
+    // };
+    //
+    // const offerFilterSaving = {
+    //   type: Boolean,
+    //   inputType: 'toggle',
+    //   defaultValue: false
+    // };
+    //
+    // const language = {
+    //   type: String,
+    //   inputType: 'dropdown',
+    //   inputChoices: ['en', 'fr', 'fi'],
+    //   defaultValue: 'en'
+    // };
+    //
+    // const compactAdvancedFilterDialog = {
+    //   type: Boolean,
+    //   inputType: 'toggle',
+    //   defaultValue: false
+    // };
+
+    const gridProps = {
+      tableData,
+      columns,
+      striped,
+      multiSort,
+      resizable,
+      editable,
+      filterable,
+      autoFilter,
+      columnReorderingAllowed,
+      hideSelectionColumn,
+      allowSortBySelection,
+      selectionMode,
+      hideActionMenu,
+      tableActions,
+      itemActions,
+      highlight,
+      selectablePageSizes
+    };
+
+    /* *************************************************************************
+     * DEMO CONFIGS
+     */
+
+    const defaultConfig = {
+      configName: 'Default',
+      configReset: true,
+      configHideProps: ['highlight, filterable']
+    };
+
+    const moreDataConfig = {
+      configName: 'More data',
+      configReset: true,
+      tableData: demoTableDataNamesLarge,
+      configHideProps: ['highlight, filterable']
+    };
+
+    const highlightConfig = {
+      configName: 'Highlight rules',
+      configReset: true,
+      tableData: demoTableDataNamesSmall,
+      highlight: demoHighlight,
+      configHideProps: ['filterable']
+    };
+
+    const moreColumnTypesConfig = {
+      configName: 'More column types',
+      configReset: true,
+      tableData: demoTableDataNamesLarge,
+      columns: demoColumnsMoreTypes,
+      configHideProps: ['highlight, filterable']
+    };
+
+    const advancedFilterConfig = {
+      configName: 'Advanced filters',
+      configReset: true,
+      tableData: demoTableDataNamesLarge,
+      columns: demoColumnsMoreTypes,
+      filterable: true,
+      configHideProps: ['highlight']
+    };
+
+    const gridConfigs = [
+      defaultConfig,
+      moreDataConfig,
+      highlightConfig,
+      moreColumnTypesConfig,
+      advancedFilterConfig
+    ];
+
+    /* *************************************************************************
+     * DEMO COMPONENT
+     */
+
+    Polymer({
+      is: 'px-data-grid-paginated-demo',
+
+      properties: {
+        props: {
+          type: Object,
+          value: () => gridProps
+        },
+        configs: {
+          type: Array,
+          value: () => gridConfigs
+        }
+      },
+
+      /**
+       * Called when the user selects an action from the table action menu.
+       */
+      handleTableAction(e) {
+        if (e.detail.id === 'CSV') {
+          this.exportToCsv();
+        }
+      },
+
+      /**
+       * Exports the grid data to a CSV. Demonstrates how an app would implement
+       * this functionality.
+       */
+      exportToCsv() {
+        const grid = this.shadowRoot ? this.shadowRoot.querySelector('px-data-grid-paginated') : this.querySelector('px-data-grid-paginated');
+        const data = grid.getData();
+        const columns = grid.getVisibleColumns();
+
+        let csvContent = 'data:text/csv;charset=utf-8,';
+        csvContent += columns.map((column) => grid.resolveColumnHeader(column)).join(',') + '\r\n';
+        data.forEach((item) => {
+          csvContent += Object.keys(item).map((key) => item[key]).join(',') + '\r\n';
         });
+
+        const encodedUri = encodeURI(csvContent);
+        const link = document.createElement('a');
+        link.setAttribute('href', encodedUri);
+        link.setAttribute('download', 'table_data.csv');
+        document.body.appendChild(link);
+
+        link.click();
       }
-      return data;
-    },
-
-    tableActionListener: function(evt) {
-      if (evt.detail.id === 'CSV') {
-        this.exportToCsv();
-      }
-    },
-
-    exportToCsv: function() {
-      const grid = this.shadowRoot.querySelector('px-data-grid-paginated');
-      const data = grid.getData();
-      const columns = grid.getVisibleColumns();
-      let csvContent = 'data:text/csv;charset=utf-8,';
-
-      csvContent += columns.map((column) => grid.resolveColumnHeader(column)).join(',') + '\r\n';
-      data.forEach((item) => {
-        csvContent += Object.keys(item).map((key) => item[key]).join(',') + '\r\n';
-      });
-
-      const encodedUri = encodeURI(csvContent);
-      const link = document.createElement('a');
-      link.setAttribute('href', encodedUri);
-      link.setAttribute('download', 'table_data.csv');
-      document.body.appendChild(link);
-
-      link.click();
-    }
-  });
+    });
+  }
 </script>

--- a/demo/px-data-grid-paginated-demo.html
+++ b/demo/px-data-grid-paginated-demo.html
@@ -53,7 +53,7 @@
     <!-- Header -->
     <px-demo-header
         module-name="px-data-grid-paginated"
-        description="Paginated version of the data grid. The data grid displays tabular data with rich interactions to help users find, manage, and update important information. The px-data-grid component replaces the legacy px-data-table component and offers a wide range of new behaviors. The grid is complete rewrite with a new API and more features that targets Polymer 2+ runtime."
+        description="Paginated version of the data grid. The data grid displays tabular data with rich interactions to help users find, manage, and update important information. The px-data-grid component replaces the legacy px-data-table component and offers a wide range of new behaviors. The grid is a complete rewrite with a new API and more features that targets Polymer 2+ runtime."
         github-org="predixdesignsystem"
         mobile desktop tablet>
     </px-demo-header>
@@ -83,7 +83,6 @@
             column-reordering-allowed="{{props.columnReorderingAllowed.value}}"
             hide-selection-column="{{props.hideSelectionColumn.value}}"
             selection-mode="{{props.selectionMode.value}}"
-            allow-sort-by-selection="{{props.allowSortBySelection.value}}"
             hide-action-menu="{{props.hideActionMenu.value}}"
             table-actions="{{props.tableActions.value}}"
             item-actions="{{props.itemActions.value}}"
@@ -627,12 +626,6 @@
       defaultValue: false
     };
 
-    const allowSortBySelection = {
-      type: Boolean,
-      inputType: 'toggle',
-      defaultValue: false
-    };
-
     const selectionMode = {
       type: String,
       inputType: 'dropdown',
@@ -736,7 +729,6 @@
       autoFilter,
       columnReorderingAllowed,
       hideSelectionColumn,
-      allowSortBySelection,
       selectionMode,
       hideActionMenu,
       tableActions,


### PR DESCRIPTION
Adds a demo for px-data-grid-paginated. Uses the same options from px-data-grid, and adds the `selectablePageSizes` property that is unique to px-data-grid-paginated.

