### PR TITLE
Make private column._element property writable, check before defining

### DIFF
--- a/px-data-grid-column.html
+++ b/px-data-grid-column.html
@@ -149,11 +149,15 @@
         }
 
         _mappedObjectChanged(obj) {
-          if (obj) {
+          if (obj && !obj.hasOwnProperty('_element')) {
             Object.defineProperty(obj, '_element', {
               value: this,
-              enumerable: false
+              enumerable: false,
+              writable: true
             });
+          }
+          if (obj && obj.hasOwnProperty('_element') && obj._element !== this) {
+            obj._element = this;
           }
         }
 


### PR DESCRIPTION
Fixes #737 

Calling Object.defineProperty(...) in px-data-grid-column#_mappedObjectChanged
was created a non-writable property on the column object. Sometimes
when we hit that method again for a column that had already been
used a TypeError was thrown saying that _element was non-writable and
could not be re-assigned using Object.defineProperty().

Adds a check to ensure that _element should be redefined if we hit
the method again, and marks the _element property as explicitly
writable when it is defined to ensure we don't hit the runtime
error again when redefining it.