### PR TITLE
Adding timezone support

### DIFF
--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -128,7 +128,7 @@
         first: 'Elizabeth',
         last: 'Wong',
         email: 'sika@iknulber.cl',
-        born: '1995-04-12',
+        born: '1995-04-12 17:00',
         age: 23
       },
       {
@@ -168,329 +168,376 @@
         full: 'Elizabeth Wong',
         email: 'sika@iknulber.cl',
         born: '1985-04-12',
-        age: 32
+        age: 32,
+        appointment: '2010-03-04 00:00'
       },
       {
         first: 'Jeffrey',
         last: 'Hamilton',
         email: 'cofok@rac.be',
         born: '1995-04-12',
-        age: 23
+        age: 23,
+        appointment: '2010-03-04 01:10'
       },
       {
         first: 'Alma',
         last: 'Martin',
         email: 'dotta@behtam.la',
         born: '1975-04-12',
-        age: 42
+        age: 42,
+        appointment: '2010-03-04 02:20'
       },
       {
         first: 'Carl',
         last: 'Saunders',
         email: 'seh@bibapu.gy',
         born: '2002-04-12',
-        age: 12
+        age: 12,
+        appointment: '2010-03-04 03:30'
       },
       {
         first: 'Willie',
         last: 'Dennis',
         email: 'izko@dahokwej.ci',
         born: '1973-04-12',
-        age: 44
+        age: 44,
+        appointment: '2010-03-04 04:40'
       },
       {
         first: 'Angel',
         last: 'Lewis',
         email: 'ma@et.nz',
         born: '1932-04-12',
-        age: 89
+        age: 89,
+        appointment: '2010-03-04 05:50'
       },
       {
         first: 'Jessie',
         last: 'Sherman',
         email: 'hunocnas@mosuraj.gi',
         born: '1990-04-12',
-        age: 27
+        age: 27,
+        appointment: '2010-03-04 06:00'
       },
       {
         first: 'Eric',
         last: 'Brewer',
         email: 'tu@coajoul.de',
         born: '1930-04-12',
-        age: 88
+        age: 88,
+        appointment: '2010-03-04 07:00'
       },
       {
         first: 'Cory',
         last: 'Ramos',
         email: 'kilamja@oviafbek.ss',
         born: '2006-04-12',
-        age: 9
+        age: 9,
+        appointment: '2010-03-04 08:00'
       },
       {
         first: 'Bertie',
         last: 'Ross',
         email: 'ifuvu@getvi.my',
         born: '1990-04-12',
-        age: 27
+        age: 27,
+        appointment: '2010-03-04 09:00'
       },
       {
         first: 'Oscar',
         last: 'Estrada',
         email: 'minu@kerireg.gp',
         born: '2002-04-12',
-        age: 15
+        age: 15,
+        appointment: '2010-03-04 10:00'
       },
       {
         first: 'Estelle',
         last: 'Patton',
         email: 'hudliami@lijihen.fi',
         born: '2006-04-12',
-        age: 11
+        age: 11,
+        appointment: '2010-03-04 11:00'
       },
       {
         first: 'Sallie',
         last: 'George',
         email: 'wo@zof.bf',
         born: '1985-04-12',
-        age: 33
+        age: 33,
+        appointment: '2010-03-04 12:00'
       },
       {
         first: 'Harriett',
         last: 'Wheeler',
         email: 'woguw@cibevo.pt',
         born: '1968-04-12',
-        age: 52
+        age: 52,
+        appointment: '2010-03-04 13:00'
       },
       {
         first: 'Bryan',
         last: 'Houston',
         email: 'tekkubom@gaahu.ge',
         born: '1940-04-12',
-        age: 77
+        age: 77,
+        appointment: '2010-03-04 14:00'
       },
       {
         first: 'Leon',
         last: 'Craig',
         email: 'wo@gurozo.gs',
         born: '2015-04-12',
-        age: 2
+        age: 2,
+        appointment: '2010-03-04 15:00'
       },
       {
         first: 'Mable',
         last: 'Taylor',
         email: 'um@fegnocka.pg',
         born: '2006-04-12',
-        age: 11
+        age: 11,
+        appointment: '2010-03-04 16:00'
       },
       {
         first: 'Ida',
         last: 'Hansen',
         email: 'lufahu@gewlaskoc.kh',
         born: '1973-04-12',
-        age: 44
+        age: 44,
+        appointment: '2010-03-04 17:00'
       },
       {
         first: 'Adele',
         last: 'Thornton',
         email: 'gugugo@nevigi.th',
         born: '1973-04-12',
-        age: 41
+        age: 41,
+        appointment: '2010-03-04 18:00'
       },
       {
         first: 'Jerry',
         last: 'Kelley',
         email: 'solef@zoose.as',
         born: '1950-04-12',
-        age: 67
+        age: 67,
+        appointment: '2010-03-04 19:00'
       },
       {
         first: 'Clara',
         last: 'Delgado',
         email: 'fivticnuf@upkib.rw',
         born: '1951-04-12',
-        age: 66
+        age: 66,
+        appointment: '2010-03-04 20:00'
       },
       {
         first: 'Joseph',
         last: 'Stevenson',
         email: 'be@viijo.lk',
         born: '1995-04-12',
-        age: 22
+        age: 22,
+        appointment: '2010-03-04 21:00'
       },
       {
         first: 'Ellen',
         last: 'Perry',
         email: 'ce@jewo.sv',
         born: '1996-04-12',
-        age: 23
+        age: 23,
+        appointment: '2010-03-04 22:00'
       },
       {
         first: 'Ronnie',
         last: 'Cummings',
         email: 'iro@wi.vn',
         born: '2000-04-12',
-        age: 17
+        age: 17,
+        appointment: '2010-03-04 23:00'
       },
       {
         first: 'Olive',
         last: 'Santos',
         email: 'vo@nees.cn',
         born: '1918-04-12',
-        age: 99
+        age: 99,
+        appointment: '2010-03-05 00:00'
       },
       {
         first: 'Rena',
         last: 'Tucker',
         email: 'uharoc@lohpol.gl',
         born: '1915-04-12',
-        age: 102
+        age: 102,
+        appointment: '2010-03-05 01:00'
       },
       {
         first: 'Nell',
         last: 'Hicks',
         email: 'felaf@vo.sb',
         born: '1940-04-12',
-        age: 76
+        age: 76,
+        appointment: '2010-03-05 02:00'
       },
       {
         first: 'Jesus',
         last: 'Hawkins',
         email: 'wahgab@mu.mk',
         born: '1983-04-12',
-        age: 34
+        age: 34,
+        appointment: '2010-03-05 03:00'
       },
       {
         first: 'Duane',
         last: 'Harris',
         email: 'kellanjob@daava.ph',
         born: '1996-04-12',
-        age: 23
+        age: 23,
+        appointment: '2010-03-05 04:00'
       },
       {
         first: 'Jonathan',
         last: 'Holmes',
         email: 'jir@bikuf.dj',
         born: '1969-04-12',
-        age: 49
+        age: 49,
+        appointment: '2010-03-05 05:00'
       },
       {
         first: 'Christine',
         last: 'Collier',
         email: 'bocago@jerla.ba',
         born: '1970-04-12',
-        age: 48
+        age: 48,
+        appointment: '2010-03-05 06:00'
       },
       {
         first: 'Brandon',
         last: 'Thompson',
         email: 'regoh@ji.kn',
         born: '1973-04-12',
-        age: 43
+        age: 43,
+        appointment: '2010-03-05 07:00'
       },
       {
         first: 'Anne',
         last: 'Dunn',
         email: 'samhof@are.sc',
         born: '1976-04-12',
-        age: 41
+        age: 41,
+        appointment: '2010-03-05 08:00'
       },
       {
         first: 'Viola',
         last: 'Sherman',
         email: 'wep@kezori.lt',
         born: '1973-04-12',
-        age: 44
+        age: 44,
+        appointment: '2010-03-05 09:00'
       },
       {
         first: 'Kathryn',
         last: 'Harper',
         email: 'keotoci@je.mr',
         born: '1941-04-12',
-        age: 77
+        age: 77,
+        appointment: '2010-03-05 10:00'
       },
       {
         first: 'Calvin',
         last: 'Bates',
         email: 'bomeg@lip.bw',
         born: '1979-04-12',
-        age: 38
+        age: 38,
+        appointment: '2010-03-05 11:00'
       },
       {
         first: 'Maggie',
         last: 'Collins',
         email: 'zonefto@ihihij.ke',
         born: '1982-04-12',
-        age: 35
+        age: 35,
+        appointment: '2010-03-05 12:00'
       },
       {
         first: 'Zachary',
         last: 'Mitchell',
         email: 'wamez@cilvahbod.mk',
         born: '1993-04-12',
-        age: 26
+        age: 26,
+        appointment: '2010-03-05 13:00'
       },
       {
         first: 'Raymond',
         last: 'Kelley',
         email: 'wuz@napujos.tt',
         born: '1995-04-12',
-        age: 21
+        age: 21,
+        appointment: '2010-03-05 14:00'
       },
       {
         first: 'Augusta',
         last: 'Torres',
         email: 'bum@ne.lt',
         born: '1967-04-12',
-        age: 54
+        age: 54,
+        appointment: '2010-03-05 15:00'
       },
       {
         first: 'Charlie',
         last: 'Lindsey',
         email: 'ruhlu@tuobujen.ao',
         born: '2002-04-12',
-        age: 15
+        age: 15,
+        appointment: '2010-03-05 16:00'
       },
       {
         first: 'Jeremy',
         last: 'Swanson',
         email: 'ed@ted.km',
         born: '1997-04-12',
-        age: 21
+        age: 21,
+        appointment: '2010-03-05 17:00'
       },
       {
         first: 'Joel',
         last: 'Gonzalez',
         email: 'ej@pot.bz',
         born: '1999-04-12',
-        age: 18
+        age: 18,
+        appointment: '2010-03-05 18:00'
       },
       {
         first: 'Lillie',
         last: 'Hawkins',
         email: 'uguiv@mudbuve.pa',
         born: '1975-04-12',
-        age: 43
+        age: 43,
+        appointment: '2010-03-05 19:00'
       },
       {
         first: 'Joel',
         last: 'Watts',
         email: 'naafe@oli.bb',
         born: '2017-04-12',
-        age: 1
+        age: 1,
+        appointment: '2010-03-05 20:00'
       },
       {
         first: 'Isabella',
         last: 'Sandoval',
         email: 'asobu@wedef.af',
         born: '2016-04-12',
-        age: 3
+        age: 3,
+        appointment: '2010-03-05 21:00'
       },
       {
         first: 'Roy',
         last: 'Lyons',
         email: 'rasaogu@tadiri.tc',
         born: '1924-04-12',
-        age: 88
+        age: 88,
+        appointment: '2010-03-05 22:00'
       }
     ];
 
@@ -527,7 +574,29 @@
       {
         name: 'Birth Date',
         path: 'born',
+        dateFormat: {
+          format: 'YYYY-MM-DD'
+        },
         renderer: 'px-data-grid-date-renderer',
+        rendererConfig: {
+          hideTime: true,
+          displayFormat: 'YYYY/MM/DD'
+        },
+        editable: true,
+        type: 'date'
+      },
+      {
+        name: 'Appointment',
+        path: 'appointment',
+        dateFormat: {
+          format: 'YYYY-MM-DD HH:mm:ss',
+          timezone: 'UTC'
+        },
+        renderer: 'px-data-grid-date-renderer',
+        rendererConfig: {
+          displayFormat: 'YYYY/MM/DD HH:mm:ss',
+          timezone: 'America/Los_Angeles'
+        },
         editable: true,
         type: 'date'
       }

--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -589,7 +589,7 @@
         name: 'Appointment',
         path: 'appointment',
         dateFormat: {
-          format: 'YYYY-MM-DD HH:mm:ss',
+          format: 'YYYY-MM-DD HH:mm',
           timezone: 'UTC'
         },
         filterByTime: true,

--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -169,7 +169,7 @@
         email: 'sika@iknulber.cl',
         born: '1985-04-12',
         age: 32,
-        appointment: '2010-03-04 00:00'
+        appointment: '2009-05-05 01:10'
       },
       {
         first: 'Jeffrey',
@@ -177,7 +177,7 @@
         email: 'cofok@rac.be',
         born: '1995-04-12',
         age: 23,
-        appointment: '2010-03-04 01:10'
+        appointment: '2011-03-04 01:10'
       },
       {
         first: 'Alma',
@@ -594,7 +594,7 @@
         },
         renderer: 'px-data-grid-date-renderer',
         rendererConfig: {
-          displayFormat: 'YYYY/MM/DD HH:mm:ss',
+          displayFormat: 'MM/DD/YYYY HH:mm:ss',
           timezone: 'America/Los_Angeles'
         },
         editable: true,

--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -592,10 +592,14 @@
           format: 'YYYY-MM-DD HH:mm:ss',
           timezone: 'UTC'
         },
+        filterByTime: true,
         renderer: 'px-data-grid-date-renderer',
         rendererConfig: {
-          displayFormat: 'MM/DD/YYYY HH:mm:ss',
-          timezone: 'America/Los_Angeles'
+          hideTime: false,
+          displayFormat: 'MM/DD/YYYY HH:mm',
+          timezone: 'America/Los_Angeles',
+          datePickerDateFormat: 'MM/DD/YYYY',
+          datePickerTimeFormat: 'HH:mm'
         },
         editable: true,
         type: 'date'

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -37,7 +37,7 @@ Make date-renderer columns use ellipsis overflow:
       <div class="input-container">
         <px-datetime-picker
           id="editingTemplateInput"
-          moment-obj="{{momentObj}}"
+          moment-obj="[[_generateMomentObj(value)]]"
           hide-time="[[hideTime]]"
           hide-date="[[hideDate]]"
           time-zone="[[displayTimezone]]"
@@ -76,9 +76,6 @@ Make date-renderer columns use ellipsis overflow:
 
         static get properties() {
           return {
-            momentObj: {
-              type: Object
-            },
             /**
              * Format to be displayed in the cell
              * A moment.js string formatter or 'ISO'
@@ -136,7 +133,6 @@ Make date-renderer columns use ellipsis overflow:
         static get observers() {
           return [
             '_valueObserver(value)',
-            '_momentObjChanged(momentObj, momentObj.*)',
             '_rendererConfigChanged(column.rendererConfig.*)',
             '_dateFormatConfigChanged(column.dateFormat.*)'
           ];
@@ -171,6 +167,10 @@ Make date-renderer columns use ellipsis overflow:
         }
 
         validate() {
+          const field = this.shadowRoot.querySelector('px-datetime-picker');
+          if (field) {
+            this.value = this._convertToValue(field.momentObj);
+          }
           return {
             valid: (!this.column.required && this.value) || (!this.value || window.Px.moment(this.value, this.dataFormat).isValid()),
             message: this.localize('Date is invalid')
@@ -183,32 +183,21 @@ Make date-renderer columns use ellipsis overflow:
             this._initialType = typeof value;
           }
 
-          if (value || value === 0) {
-            if (this.dataFormat === 'ISO') {
-              this.momentObj = window.Px.moment(value);
-            } else {
-              this.momentObj = window.Px.moment(value, this.dataFormat, true);
-            }
-          } else {
-            this.momentObj = undefined;
-          }
         }
 
-        _momentObjChanged(momentObj) {
+        _convertToValue(momentObj) {
           if (!momentObj) {
-            return;
+            return undefined;
           }
 
-          if (window.Px.moment(this.value, this.dataFormat).toISOString() !== momentObj.toISOString()) {
 
-            // for timestamp-like data try to preserve the type
-            if (this._initialType === 'number' && (this.dataFormat === 'X' || this.dataFormat === 'x')) {
-              this.value = Number(momentObj.format(this.dataFormat));
-            } else if (this.dataFormat === 'ISO') {
-              this.value = momentObj.toISOString();
-            } else {
-              this.value = momentObj.format(this.dataFormat);
-            }
+          // for timestamp-like data try to preserve the type
+          if (this._initialType === 'number' && (this.dataFormat === 'X' || this.dataFormat === 'x')) {
+            return Number(momentObj.tz(this.timezone).format(this.dataFormat));
+          } else if (this.dataFormat === 'ISO') {
+            return momentObj.toISOString();
+          } else {
+            return momentObj.tz(this.timezone).format(this.dataFormat);
           }
         }
 
@@ -224,6 +213,22 @@ Make date-renderer columns use ellipsis overflow:
           } else {
             this.timezone = 'UTC';
           }
+        }
+
+        _generateMomentObj(value) {
+          let newMomentObj;
+
+          if (value || value === 0) {
+            if (this.dataFormat === 'ISO') {
+              newMomentObj = window.Px.moment(value);
+            } else {
+              newMomentObj = window.Px.moment.tz(value, this.dateFormat, this.timezone);
+            }
+          } else {
+            newMomentObj = undefined;
+          }
+
+          return newMomentObj;
         }
 
         _rendererConfigChanged(rendererConfig) {

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -40,6 +40,8 @@ Make date-renderer columns use ellipsis overflow:
           moment-obj="{{momentObj}}"
           hide-time="[[hideTime]]"
           hide-date="[[hideDate]]"
+          time-zone="[[displayTimezone]]"
+          show-time-zone="abbreviatedText"
           date-format="[[datePickerDateFormat]]"
           time-format="[[datePickerTimeFormat]]"
           hoist>

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -141,7 +141,6 @@ Make date-renderer columns use ellipsis overflow:
         }
 
         _getFormattedDate(value) {
-          window.format = this;
           var result;
           if (value) {
             let momentValue;

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -146,7 +146,7 @@ Make date-renderer columns use ellipsis overflow:
             if (this.dateFormat === 'ISO') {
               momentValue = window.Px.moment(value);
             } else {
-              momentValue = window.Px.moment.tz(value, this.dateFormat, true, this.timezone);
+              momentValue = window.Px.moment.tz(value, this.dateFormat, this.timezone);
             }
             // format for display
             if (momentValue) {

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -146,7 +146,7 @@ Make date-renderer columns use ellipsis overflow:
             if (this.dateFormat === 'ISO') {
               momentValue = window.Px.moment(value);
             } else {
-              momentValue = window.Px.moment.tz(value, this.dateFormat, this.timezone);
+              momentValue = window.Px.moment.tz(value, this.dateFormat, true, this.timezone);
             }
             // format for display
             if (momentValue) {
@@ -189,15 +189,13 @@ Make date-renderer columns use ellipsis overflow:
           if (!momentObj) {
             return undefined;
           }
-
-
           // for timestamp-like data try to preserve the type
           if (this._initialType === 'number' && (this.dataFormat === 'X' || this.dataFormat === 'x')) {
             return Number(momentObj.tz(this.timezone).format(this.dataFormat));
           } else if (this.dataFormat === 'ISO') {
             return momentObj.toISOString();
           } else {
-            return momentObj.tz(this.timezone).format(this.dataFormat);
+            return momentObj.tz(this.timezone).format(this.dateFormat);
           }
         }
 
@@ -222,13 +220,17 @@ Make date-renderer columns use ellipsis overflow:
             if (this.dataFormat === 'ISO') {
               newMomentObj = window.Px.moment(value);
             } else {
-              newMomentObj = window.Px.moment.tz(value, this.dateFormat, this.timezone);
+              newMomentObj = window.Px.moment.tz(value, this.dateFormat, true, this.timezone);
             }
           } else {
             newMomentObj = undefined;
           }
 
-          return newMomentObj;
+          if (newMomentObj && newMomentObj.isValid()) {
+            return newMomentObj;
+          } else {
+            return undefined;
+          }
         }
 
         _rendererConfigChanged(rendererConfig) {

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -86,12 +86,13 @@ Make date-renderer columns use ellipsis overflow:
               value: 'YYYY-MM-DD'
             },
             /**
-             * Format for reading the data
-             * A moment.js string formatter or 'ISO'
+             * Timezone to be used for displaying the date.
+             * The original date value will be converted to this
+             * timezone if needed.
              */
-            dataFormat: {
+            timezone: {
               type: String,
-              value: 'YYYY-MM-DD'
+              value: 'UTC'
             },
             /**
              * Format for px-datepicker's dateFormat
@@ -134,26 +135,28 @@ Make date-renderer columns use ellipsis overflow:
           return [
             '_valueObserver(value)',
             '_momentObjChanged(momentObj, momentObj.*)',
-            '_rendererConfigChanged(column.rendererConfig.*)'
+            '_rendererConfigChanged(column.rendererConfig.*)',
+            '_dateFormatConfigChanged(column.dateFormat.*)'
           ];
         }
 
         _getFormattedDate(value) {
-
+          window.format = this;
           var result;
           if (value) {
             let momentValue;
-            if (this.dataFormat === 'ISO') {
+            // read timestamp data
+            if (this.dateFormat === 'ISO') {
               momentValue = window.Px.moment(value);
             } else {
-              momentValue = window.Px.moment(value, this.dataFormat, true);
+              momentValue = window.Px.moment.tz(value, this.dateFormat, this.timezone);
             }
-
+            // format for display
             if (momentValue) {
               if (this.displayFormat === 'ISO') {
                 result = momentValue.toISOString();
               } else {
-                result = momentValue.format(this.displayFormat);
+                result = momentValue.tz(this.displayTimezone).format(this.displayFormat);
               }
             } else {
               console.warn('Unknown date value: "' + value + '"');
@@ -208,6 +211,20 @@ Make date-renderer columns use ellipsis overflow:
           }
         }
 
+        _dateFormatConfigChanged(dateFormat) {
+          if (dateFormat && dateFormat.value && dateFormat.value.hasOwnProperty('format')) {
+            this.dateFormat = dateFormat.value.format;
+          } else {
+            this.dateFormat = 'YYYY-MM-DD';
+          }
+
+          if (dateFormat && dateFormat.value && dateFormat.value.hasOwnProperty('timezone')) {
+            this.timezone = dateFormat.value.timezone;
+          } else {
+            this.timezone = 'UTC';
+          }
+        }
+
         _rendererConfigChanged(rendererConfig) {
 
           if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('hideDate')) {
@@ -228,10 +245,10 @@ Make date-renderer columns use ellipsis overflow:
             this.displayFormat = 'YYYY-MM-DD';
           }
 
-          if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('dataFormat')) {
-            this.dataFormat = rendererConfig.value.dataFormat;
+          if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('timezone')) {
+            this.displayTimezone = rendererConfig.value.timezone;
           } else {
-            this.dataFormat = 'YYYY-MM-DD';
+            this.displayTimezone = 'UTC';
           }
 
           if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('datePickerDateFormat')) {

--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -85,9 +85,8 @@
             id="date-rangepicker"
             hide-time="[[_hideTime]]"
             hide-presets
-            date-format="YYYY/MM/DD"
-            time-format="HH:mm:ss"
-            time-zone="UTC"
+            date-format="[[_displayDateFormat]]"
+            time-zone="[[_displayTimezone]]"
             show-time-zone="abbreviatedText"
             show-field-titles
             from-moment="{{_dateFrom}}"
@@ -262,6 +261,22 @@
               type: Object
             },
 
+            _sourceDateFormat: {
+              type: String
+            },
+
+            _sourceTimezone: {
+              type: String
+            },
+
+            _displayDateFormat: {
+              type: String
+            },
+
+            _displayTimezone: {
+              type: String
+            },
+
             localize: Function
           };
         }
@@ -330,6 +345,19 @@
             this.set('_hideTime', false);
           } else {
             this.set('_hideTime', true);
+          }
+          this.set('_hideTime', true);
+
+          // source data format
+          if (selectedColumn.dateFormat) {
+            this.set('_sourceDateFormat', selectedColumn.dateFormat.format || 'YYYY/MM/DDD HH:mm:ss');
+            this.set('_sourceTimezone', selectedColumn.dateFormat.timezone || 'UTC');
+          }
+
+          // display data format
+          if (selectedColumn.rendererConfig) {
+            this.set('_displayDateFormat', selectedColumn.rendererConfig.displayFormat || 'YYYY/MM/DD HH:mm:ss');
+            this.set('_displayTimezone', selectedColumn.rendererConfig.timezone || 'UTC');
           }
         }
 
@@ -477,10 +505,10 @@
 
         _momentDatesObserver(dateFrom, dateTo) {
           if (dateFrom && window.Px.moment(this.entity.dateFrom).format() !== dateFrom.format()) {
-            this.set('entity.dateFrom', dateFrom.format());
+            this.set('entity.dateFrom', dateFrom.tz(this._sourceTimezone).format(this._sourceDateFormat));
           }
           if (dateTo && window.Px.moment(this.entity.dateTo).format() !== dateTo.format()) {
-            this.set('entity.dateTo', dateTo.format());
+            this.set('entity.dateTo', dateTo.tz(this._sourceTimezone).format(this._sourceDateFormat));
           }
         }
 

--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -53,7 +53,7 @@
             hide-presets
             date-format="YYYY/MM/DD"
             time-format="HH:mm:ss"
-            time-zone="UTC"
+            time-zone="[[_displayTimezone]]"
             show-time-zone="[[_showTimeZone]]"
             show-field-titles
             from-moment="{{_dateFrom}}"

--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -86,6 +86,7 @@
             hide-time="[[_hideTime]]"
             hide-presets
             date-format="[[_displayDateFormat]]"
+            time-format="[[_displayTimeFormat]]"
             time-zone="[[_displayTimezone]]"
             show-time-zone="abbreviatedText"
             show-field-titles
@@ -346,7 +347,6 @@
           } else {
             this.set('_hideTime', true);
           }
-          this.set('_hideTime', true);
 
           // source data format
           if (selectedColumn.dateFormat) {
@@ -356,7 +356,8 @@
 
           // display data format
           if (selectedColumn.rendererConfig) {
-            this.set('_displayDateFormat', selectedColumn.rendererConfig.displayFormat || 'YYYY/MM/DD HH:mm:ss');
+            this.set('_displayDateFormat', selectedColumn.rendererConfig.datePickerDateFormat || 'YYYY/MM/DD');
+            this.set('_displayTimeFormat', selectedColumn.rendererConfig.datePickerTimeFormat || 'HH:mm');
             this.set('_displayTimezone', selectedColumn.rendererConfig.timezone || 'UTC');
           }
         }

--- a/px-data-grid-filterable-mixin.html
+++ b/px-data-grid-filterable-mixin.html
@@ -108,6 +108,9 @@
     _isDateMatches(filter, value) {
       let result = true;
       const comparingDate = window.Px.moment.utc(value);
+      if (!comparingDate) {
+        result = false;
+      }
       if (filter.dateFrom) {
         const dateFrom = window.Px.moment.utc(filter.dateFrom);
         result = result && dateFrom < comparingDate;

--- a/px-data-grid-filterable-mixin.html
+++ b/px-data-grid-filterable-mixin.html
@@ -107,13 +107,13 @@
 
     _isDateMatches(filter, value) {
       let result = true;
-      const comparingDate = new Date(value);
+      const comparingDate = window.Px.moment.utc(value);
       if (filter.dateFrom) {
-        const dateFrom = new Date(filter.dateFrom);
+        const dateFrom = window.Px.moment.utc(filter.dateFrom);
         result = result && dateFrom < comparingDate;
       }
       if (filter.dateTo) {
-        const dateTo = new Date(filter.dateTo);
+        const dateTo = window.Px.moment.utc(filter.dateTo);
         result = result && dateTo > comparingDate;
       }
       return result;

--- a/px-data-grid-filters-preview.html
+++ b/px-data-grid-filters-preview.html
@@ -157,8 +157,8 @@
               break;
             case 'date': {
               return `Date Range \/
-                ${this._getFormattedDate(entity.dateFrom, column)} ${this._getDisplayTimezone(column)} -
-                ${this._getFormattedDate(entity.dateTo, column)} ${this._getDisplayTimezone(column)}
+                ${this._formatDateForTooltip(entity.dateFrom, column)} ${this._getDisplayTimezone(column)} -
+                ${this._formatDateForTooltip(entity.dateTo, column)} ${this._getDisplayTimezone(column)}
               `;
             }
             default:
@@ -179,8 +179,8 @@
               break;
             case 'date': {
               return `
-                ${this._getFormattedDate(entity.dateFrom, column)} -
-                ${this._getFormattedDate(entity.dateTo, column)}
+                ${this._formatDateForChip(entity.dateFrom, column)} -
+                ${this._formatDateForChip(entity.dateTo, column)}
               `;
             }
             default:
@@ -200,7 +200,19 @@
           return flattenFilterEntities.length > 1;
         }
 
-        _getFormattedDate(value, column) {
+        _formatDateForTooltip(value, column) {
+          return this._getFormattedDate(value, column,
+            this._getSourceTimezone(column), this._getSourceFormat(column),
+            this._getDisplayTimezone(column), this._getDisplayFormat(column));
+        }
+
+        _formatDateForChip(value, column) {
+          return this._getFormattedDate(value, column,
+            this._getSourceTimezone(column), this._getSourceFormat(column),
+            this._getDisplayTimezone(column), 'YYYY/MM/DD'); // GE requirement to force this format
+        }
+
+        _getFormattedDate(value, column, sourceTimezone, sourceFormat, displayTimezone, displayFormat) {
           var result;
           if (value) {
             let momentValue;
@@ -208,8 +220,6 @@
             if (this.dateFormat === 'ISO') {
               momentValue = window.Px.moment(value);
             } else {
-              const sourceTimezone = this._getSourceTimezone(column);
-              const sourceFormat = this._getSourceFormat(column);
               momentValue = window.Px.moment.tz(value, sourceFormat, sourceTimezone);
             }
             // format for display
@@ -217,8 +227,6 @@
               if (this.displayFormat === 'ISO') {
                 result = momentValue.toISOString();
               } else {
-                const displayTimezone = this._getDisplayTimezone(column);
-                const displayFormat = this._getDisplayFormat(column);
                 result = momentValue.tz(displayTimezone).format(displayFormat);
               }
             } else {

--- a/px-data-grid-filters-preview.html
+++ b/px-data-grid-filters-preview.html
@@ -181,8 +181,8 @@
             case 'date': {
               const format = this._getTitleDateFormat(column);
               return `
-                ${window.Px.moment(entity.dateFrom).format(format)} ${this._getTimezone(column)} -
-                ${window.Px.moment(entity.dateTo).format(format)} ${this._getTimezone(column)}
+                ${window.Px.moment(entity.dateFrom).format(format)} -
+                ${window.Px.moment(entity.dateTo).format(format)}
               `;
             }
             default:

--- a/px-data-grid-filters-preview.html
+++ b/px-data-grid-filters-preview.html
@@ -156,8 +156,8 @@
               }
               break;
             case 'date': {
-              const format = this._getTimeStampFormat(column);
-              return `Range \/ ${window.Px.moment(entity.dateFrom).format(format)} - ${window.Px.moment(entity.dateTo).format(format)}`;
+              const format = this._getTooltipDateFormat(column);
+              return `Date Range \/ ${window.Px.moment(entity.dateFrom).format(format)} - ${window.Px.moment(entity.dateTo).format(format)}`;
             }
             default:
               return `${section.action} ${section.operationType} / ${name} / ${entity.pattern}`;
@@ -176,7 +176,7 @@
               }
               break;
             case 'date': {
-              const format = this._getDateFormat(column);
+              const format = this._getTitleDateFormat(column);
               return `${window.Px.moment(entity.dateFrom).format(format)}-${window.Px.moment(entity.dateTo).format(format)}`;
             }
             default:
@@ -196,7 +196,7 @@
           return flattenFilterEntities.length > 1;
         }
 
-        _getDateFormat(column) {
+        _getTitleDateFormat(column) {
           if (column.rendererConfig && column.rendererConfig.displayFormat) {
             return column.rendererConfig.displayFormat;
           } else {
@@ -204,10 +204,12 @@
           }
         }
 
-        _getTimeStampFormat(column) {
-          // TODO: add timezone to end of format
-          // TODO: read time format from renderConfig?
-          return 'YYYY/MM/DD, hh:mm:ss A';
+        _getTooltipDateFormat(column) {
+          if (column.rendererConfig && column.rendererConfig.displayFormat) {
+            return column.rendererConfig.displayFormat + ' z'; // append timezone
+          } else {
+            return 'YYYY/MM/DD HH:mm:ss z';
+          }
         }
       }
 

--- a/px-data-grid-filters-preview.html
+++ b/px-data-grid-filters-preview.html
@@ -157,7 +157,10 @@
               break;
             case 'date': {
               const format = this._getTooltipDateFormat(column);
-              return `Date Range \/ ${window.Px.moment(entity.dateFrom).format(format)} - ${window.Px.moment(entity.dateTo).format(format)}`;
+              return `Date Range \/
+                ${window.Px.moment(entity.dateFrom).format(format)} ${this._getTimezone(column)} -
+                ${window.Px.moment(entity.dateTo).format(format)} ${this._getTimezone(column)}
+              `;
             }
             default:
               return `${section.action} ${section.operationType} / ${name} / ${entity.pattern}`;
@@ -177,7 +180,10 @@
               break;
             case 'date': {
               const format = this._getTitleDateFormat(column);
-              return `${window.Px.moment(entity.dateFrom).format(format)}-${window.Px.moment(entity.dateTo).format(format)}`;
+              return `
+                ${window.Px.moment(entity.dateFrom).format(format)} ${this._getTimezone(column)} -
+                ${window.Px.moment(entity.dateTo).format(format)} ${this._getTimezone(column)}
+              `;
             }
             default:
               if (entity.query.length <= 15) {
@@ -204,11 +210,19 @@
           }
         }
 
+        _getTimezone(column) {
+          if (column.rendererConfig && column.rendererConfig.timezone) {
+            return column.rendererConfig.timezone;
+          } else {
+            return 'UTC';
+          }
+        }
+
         _getTooltipDateFormat(column) {
           if (column.rendererConfig && column.rendererConfig.displayFormat) {
-            return column.rendererConfig.displayFormat + ' z'; // append timezone
+            return column.rendererConfig.displayFormat;
           } else {
-            return 'YYYY/MM/DD HH:mm:ss z';
+            return 'YYYY/MM/DD HH:mm:ss';
           }
         }
       }

--- a/px-data-grid-filters-preview.html
+++ b/px-data-grid-filters-preview.html
@@ -157,8 +157,8 @@
               break;
             case 'date': {
               return `Date Range \/
-                ${this._formatDateForTooltip(entity.dateFrom, column)} ${this._getDisplayTimezone(column)} -
-                ${this._formatDateForTooltip(entity.dateTo, column)} ${this._getDisplayTimezone(column)}
+                ${this._formatDateForTooltip(entity.dateFrom, column)} -
+                ${this._formatDateForTooltip(entity.dateTo, column)}
               `;
             }
             default:

--- a/px-data-grid-filters-preview.html
+++ b/px-data-grid-filters-preview.html
@@ -156,10 +156,9 @@
               }
               break;
             case 'date': {
-              const format = this._getTooltipDateFormat(column);
               return `Date Range \/
-                ${window.Px.moment(entity.dateFrom).format(format)} ${this._getTimezone(column)} -
-                ${window.Px.moment(entity.dateTo).format(format)} ${this._getTimezone(column)}
+                ${this._getFormattedDate(entity.dateFrom, column)} ${this._getDisplayTimezone(column)} -
+                ${this._getFormattedDate(entity.dateTo, column)} ${this._getDisplayTimezone(column)}
               `;
             }
             default:
@@ -179,10 +178,9 @@
               }
               break;
             case 'date': {
-              const format = this._getTitleDateFormat(column);
               return `
-                ${window.Px.moment(entity.dateFrom).format(format)} -
-                ${window.Px.moment(entity.dateTo).format(format)}
+                ${this._getFormattedDate(entity.dateFrom, column)} -
+                ${this._getFormattedDate(entity.dateTo, column)}
               `;
             }
             default:
@@ -202,15 +200,47 @@
           return flattenFilterEntities.length > 1;
         }
 
-        _getTitleDateFormat(column) {
-          if (column.rendererConfig && column.rendererConfig.displayFormat) {
-            return column.rendererConfig.displayFormat;
+        _getFormattedDate(value, column) {
+          var result;
+          if (value) {
+            let momentValue;
+            // read timestamp data
+            if (this.dateFormat === 'ISO') {
+              momentValue = window.Px.moment(value);
+            } else {
+              const sourceTimezone = this._getSourceTimezone(column);
+              const sourceFormat = this._getSourceFormat(column);
+              momentValue = window.Px.moment.tz(value, sourceFormat, sourceTimezone);
+            }
+            // format for display
+            if (momentValue) {
+              if (this.displayFormat === 'ISO') {
+                result = momentValue.toISOString();
+              } else {
+                const displayTimezone = this._getDisplayTimezone(column);
+                const displayFormat = this._getDisplayFormat(column);
+                result = momentValue.tz(displayTimezone).format(displayFormat);
+              }
+            } else {
+              console.warn('Unknown date value: "' + value + '"');
+              result = '';
+            }
           } else {
-            return 'YYYY/MM/DD';
+            result = '';
+          }
+
+          return result;
+        }
+
+        _getSourceTimezone(column) {
+          if (column.dateFormat && column.dateFormat.timezone) {
+            return column.dateFormat.timezone;
+          } else {
+            return 'UTC';
           }
         }
 
-        _getTimezone(column) {
+        _getDisplayTimezone(column) {
           if (column.rendererConfig && column.rendererConfig.timezone) {
             return column.rendererConfig.timezone;
           } else {
@@ -218,7 +248,23 @@
           }
         }
 
-        _getTooltipDateFormat(column) {
+        _getSourceFormat(column) {
+          if (column.dateFormat && column.dateFormat.format) {
+            return column.dateFormat.format;
+          } else {
+            return 'ISO';
+          }
+        }
+
+        _getDateFormat(column) {
+          if (column.rendererConfig && column.rendererConfig.displayFormat) {
+            return column.rendererConfig.displayFormat;
+          } else {
+            return 'YYYY/MM/DD';
+          }
+        }
+
+        _getDisplayFormat(column) {
           if (column.rendererConfig && column.rendererConfig.displayFormat) {
             return column.rendererConfig.displayFormat;
           } else {

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -448,8 +448,9 @@
              *       name: 'Last 7 days',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(7, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(7, 'd').format()
              *         };
              *       }
              *     },
@@ -489,8 +490,9 @@
              *       name: 'Last 7 days',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(7, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(7, 'd').format()
              *         };
              *       }
              *     },
@@ -498,8 +500,9 @@
              *       name: 'Last 14 days',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(14, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(14, 'd').format()
              *         };
              *       }
              *     },
@@ -507,8 +510,9 @@
              *       name: 'This month',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(31, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(31, 'd').format()
              *         };
              *       }
              *     },
@@ -516,8 +520,9 @@
              *       name: 'Last month',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().subtract(1, 'M').format(),
-             *           dateFrom: window.moment().subtract(2, 'M').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').subtract(1, 'M').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(2, 'M').format()
              *         };
              *       }
              *     },

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -570,8 +570,9 @@
              *       name: 'Last 7 days',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(7, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(7, 'd').format()
              *         };
              *       }
              *     },
@@ -611,8 +612,9 @@
              *       name: 'Last 7 days',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(7, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(7, 'd').format()
              *         };
              *       }
              *     },
@@ -620,8 +622,9 @@
              *       name: 'Last 14 days',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(14, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(14, 'd').format()
              *         };
              *       }
              *     },
@@ -629,8 +632,9 @@
              *       name: 'This month',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().format(),
-             *           dateFrom: window.moment().subtract(31, 'd').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(31, 'd').format()
              *         };
              *       }
              *     },
@@ -638,8 +642,9 @@
              *       name: 'Last month',
              *       getRange: () => {
              *         return {
-             *           dateTo: window.moment().subtract(1, 'M').format(),
-             *           dateFrom: window.moment().subtract(2, 'M').format()
+             *           // use timezone of source data
+             *           dateTo: window.moment().tz('UTC').subtract(1, 'M').format(),
+             *           dateFrom: window.moment().tz('UTC').subtract(2, 'M').format()
              *         };
              *       }
              *     },

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -22,6 +22,7 @@
     "getHeaderCell": false,
     "getHeaderCellContent": false,
     "getBodyCellText": false,
-    "afterEach": false
+    "afterEach": false,
+    "getColumnConfig": false
   }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -22,6 +22,7 @@
     "getHeaderCell": false,
     "getHeaderCellContent": false,
     "getBodyCellText": false,
+    "getBodyCellTextAsString": false,
     "afterEach": false,
     "getColumnConfig": false
   }

--- a/test/column-dropdown-menu.js
+++ b/test/column-dropdown-menu.js
@@ -23,19 +23,21 @@ document.addEventListener('WebComponentsReady', () => {
       expect(getHeaderCell(grid, 1)).to.equal(lastNameHeaderCell);
 
       let visibleColumns = grid.getVisibleColumns();
-      expect(visibleColumns.length).to.be.equal(3);
+      expect(visibleColumns.length).to.be.equal(4);
       expect(visibleColumns[0].name).to.be.equal('first');
       expect(visibleColumns[1].name).to.be.equal('last');
       expect(visibleColumns[2].name).to.be.equal('email');
+      expect(visibleColumns[3].name).to.be.equal('timestamp');
 
       getHeaderCellContent(lastNameHeaderCell)._freezeColumn();
       flushVaadinGrid(grid);
 
       visibleColumns = grid.getVisibleColumns();
-      expect(visibleColumns.length).to.be.equal(3);
+      expect(visibleColumns.length).to.be.equal(4);
       expect(visibleColumns[0].name).to.be.equal('last');
       expect(visibleColumns[1].name).to.be.equal('first');
       expect(visibleColumns[2].name).to.be.equal('email');
+      expect(visibleColumns[3].name).to.be.equal('timestamp');
     });
 
     it('should move the second frozen column to the left side of the grid, before the first frozen', () => {
@@ -43,10 +45,11 @@ document.addEventListener('WebComponentsReady', () => {
       expect(getHeaderCell(grid, 1)).to.equal(lastNameHeaderCell);
 
       let visibleColumns = grid.getVisibleColumns();
-      expect(visibleColumns.length).to.be.equal(3);
+      expect(visibleColumns.length).to.be.equal(4);
       expect(visibleColumns[0].name).to.be.equal('first');
       expect(visibleColumns[1].name).to.be.equal('last');
       expect(visibleColumns[2].name).to.be.equal('email');
+      expect(visibleColumns[3].name).to.be.equal('timestamp');
 
       getHeaderCellContent(lastNameHeaderCell)._freezeColumn();
       flushVaadinGrid(grid);
@@ -54,10 +57,11 @@ document.addEventListener('WebComponentsReady', () => {
       flushVaadinGrid(grid);
 
       visibleColumns = grid.getVisibleColumns();
-      expect(visibleColumns.length).to.be.equal(3);
+      expect(visibleColumns.length).to.be.equal(4);
       expect(visibleColumns[0].name).to.be.equal('first');
       expect(visibleColumns[1].name).to.be.equal('last');
       expect(visibleColumns[2].name).to.be.equal('email');
+      expect(visibleColumns[3].name).to.be.equal('timestamp');
     });
 
     it('should not move the frozen column before selection column', () => {

--- a/test/filterable.js
+++ b/test/filterable.js
@@ -67,6 +67,10 @@ document.addEventListener('WebComponentsReady', () => {
 
       expect(grid._isDateMatches({dateFrom: '1994-12-01', dateTo: '1994-12-03'}, '1994-12-02')).to.be.true;
       expect(grid._isDateMatches({dateFrom: '1994-12-01', dateTo: '1994-12-03'}, '1994-12-04')).to.be.false;
+
+      expect(grid._isDateMatches({dateFrom: '2018-02-23T11:00:45Z', dateTo: '2018-02-23T15:35:00Z'}, '2018-02-23 11:16:49')).to.be.true;
+      expect(grid._isDateMatches({dateFrom: '2018-02-23T11:00:45Z', dateTo: '2018-02-23T15:35:00Z'}, '2018-02-23 10:37:18')).to.be.false;
+      expect(grid._isDateMatches({dateFrom: '2018-02-23T11:00:45Z', dateTo: '2018-02-23T15:35:00Z'}, '2018-02-23 15:37:18')).to.be.false;
     });
 
     it('should check number properly', () => {

--- a/test/filterable.js
+++ b/test/filterable.js
@@ -4,6 +4,7 @@ document.addEventListener('WebComponentsReady', () => {
 
     beforeEach((done) => {
       grid = fixture('px-data-grid-fixture');
+      grid.columns = getColumnConfig();
       grid.tableData = tableData;
 
       flushVaadinGrid(grid);
@@ -12,6 +13,26 @@ document.addEventListener('WebComponentsReady', () => {
         setTimeout(() => { // IE11
           window.flush(done);
         });
+      });
+    });
+
+    it('should show chips properly', (done) => {
+      grid.applyFilters([{
+        action: 'show',
+        entities: [{
+          columnId: 'timestamp[date]',
+          active: true,
+          pattern: 'equals',
+          dateFrom: '2010-10-10 11:11',
+          dateTo: '2011-11-11 19:11'
+        }]
+      }]);
+      Polymer.RenderStatus.afterNextRender(grid, () => {
+        const filtersPreview = grid.shadowRoot.querySelector('px-data-grid-filters-preview');
+        const chips = filtersPreview.shadowRoot.querySelectorAll('px-chip');
+        expect(chips.length).to.equal(1);
+        expect(chips[0].content.trim().replace(/\s+/g, ' ')).to.equal('2010/10/10 - 2011/11/11');
+        done();
       });
     });
 

--- a/test/generated-columns.js
+++ b/test/generated-columns.js
@@ -14,17 +14,19 @@ document.addEventListener('WebComponentsReady', () => {
     });
 
     it('should properly populate columns', () => {
-      expect(grid.columns.length).to.be.eql(3);
+      expect(grid.columns.length).to.be.eql(4);
       expect(grid.columns[0].name).to.be.eql('first');
       expect(grid.columns[1].name).to.be.eql('last');
       expect(grid.columns[2].name).to.be.eql('email');
+      expect(grid.columns[3].name).to.be.eql('timestamp');
     });
 
     it('should set proper column.id', () => {
-      expect(grid.columns.length).to.be.eql(3);
+      expect(grid.columns.length).to.be.eql(4);
       expect(grid.columns[0].id).to.be.eql('first[string]');
       expect(grid.columns[1].id).to.be.eql('last[string]');
       expect(grid.columns[2].id).to.be.eql('email[string]');
+      expect(grid.columns[3].id).to.be.eql('timestamp[string]');
     });
 
   });

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -185,6 +185,11 @@
     return getShadowRootShallowInnerText(renderer);
   }
 
+  function getBodyCellTextAsString(grid, row, cell) {
+    const value = getBodyCellText(grid, row, cell);
+    return (value + '').trim();
+  }
+
   /**
    * Goal: Get the visible, rendered text in a given custom element's shadow root
    *

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -2,24 +2,66 @@
   const tableData = [{
     'first': 'Elizabeth',
     'last': 'Wong',
-    'email': 'sika@iknulber.cl'
+    'email': 'sika@iknulber.cl',
+    'timestamp': '2005-05-20 0:00:00'
   }, {
     'first': 'Jeffrey',
     'last': 'Hamilton',
-    'email': 'cofok@rac.be'
+    'email': 'cofok@rac.be',
+    'timestamp': '2005-04-20 10:30:00'
   }, {
     'first': 'Alma',
     'last': 'Martin',
-    'email': 'dotta@behtam.la'
+    'email': 'dotta@behtam.la',
+    'timestamp': '2003-05-20 10:30:00'
   }, {
     'first': 'Elizabeth',
     'last': 'Saunders',
-    'email': 'seh@bibapu.gy'
+    'email': 'seh@bibapu.gy',
+    'timestamp': '2003-05-20 10:20:00'
   }, {
     'first': 'Willie',
     'last': 'Dennis',
-    'email': 'izko@dahokwej.ci'
+    'email': 'izko@dahokwej.ci',
+    'timestamp': '2010-12-20 10:30:00'
   }];
+
+
+  function getColumnConfig() {
+    return [{
+      name: 'First',
+      path: 'first',
+      renderer: 'px-data-grid-string-renderer',
+      editable: true,
+      type: 'string'
+    }, {
+      name: 'Last',
+      path: 'last',
+      renderer: 'px-data-grid-string-renderer',
+      editable: true,
+      type: 'string'
+    }, {
+      name: 'Email',
+      path: 'email',
+      renderer: 'px-data-grid-string-renderer',
+      editable: true,
+      type: 'string'
+    }, {
+      name: 'Timestamp',
+      path: 'timestamp',
+      dateFormat: {
+        format: 'YYYY-MM-DD HH:mm:ss',
+        timezone: 'UTC'
+      },
+      renderer: 'px-data-grid-date-renderer',
+      rendererConfig: {
+        displayFormat: 'MM/DD/YYYY HH:mm:ss',
+        timezone: 'America/Los_Angeles'
+      },
+      editable: true,
+      type: 'date'
+    }];
+  }
 
   function generateTableData(numRows) {
     const data = [];
@@ -27,10 +69,34 @@
       data.push({
         first: 'first-' + i,
         last: 'last-' + i,
-        email: 'email-' + i + '@stuff.com'
+        email: 'email-' + i + '@stuff.com',
+        timestamp: generateTimestamp()
       });
     }
     return data;
+  }
+
+  function generateTimestamp() {
+    let year,
+      month,
+      day,
+      hour,
+      minute,
+      second;
+    // generate date
+    year = Math.floor(Math.random() * 120) + 1900 + '';
+    month = Math.floor(Math.random() * 12) + '';
+    month = month.length < 2 ? '0' + month : month;
+    day = Math.floor(Math.random() * 31) + '';
+    day = day.length < 2 ? '0' + day : day;
+    // generate time
+    hour = Math.floor(Math.random() * 24) + '';
+    hour = hour.length < 2 ? '0' + hour : hour;
+    minute = Math.floor(Math.random() * 60) + '';
+    minute = minute.length < 2 ? '0' + minute : minute;
+    second = Math.floor(Math.random() * 60) + '';
+    second = second.length < 2 ? '0' + second : second;
+    return year + '-' + month + '-' + day + ' ' + hour + ':' + minute + ':' + second;
   }
 
   function getRows(grid) {

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -77,14 +77,13 @@
   }
 
   function generateTimestamp() {
-    let year,
-      month,
+    let month,
       day,
       hour,
       minute,
       second;
     // generate date
-    year = Math.floor(Math.random() * 120) + 1900 + '';
+    const year = Math.floor(Math.random() * 120) + 1900 + '';
     month = Math.floor(Math.random() * 12) + '';
     month = month.length < 2 ? '0' + month : month;
     day = Math.floor(Math.random() * 31) + '';

--- a/test/px-data-grid-fixture.html
+++ b/test/px-data-grid-fixture.html
@@ -71,6 +71,7 @@
     <script src="restore-layout.js"></script>
     <script src="items-without-ids.js"></script>
     <script src="renderers.js"></script>
+    <script src="timezones.js"></script>
 
   </body>
 </html>

--- a/test/px-data-grid-fixture.html
+++ b/test/px-data-grid-fixture.html
@@ -63,6 +63,7 @@
     <script src="columns-api.js"></script>
     <script src="column-dropdown-menu.js"></script>
     <script src="sorting.js"></script>
+    <script src="timezones.js"></script>
     <!-- Keep this order of pagination tests for now, or tests fail -->
     <script src="px-data-grid-paginated-test.js"></script>
     <script src="px-data-grid-navigation-test.js"></script>
@@ -71,7 +72,6 @@
     <script src="restore-layout.js"></script>
     <script src="items-without-ids.js"></script>
     <script src="renderers.js"></script>
-    <script src="timezones.js"></script>
 
   </body>
 </html>

--- a/test/renderers.js
+++ b/test/renderers.js
@@ -1,9 +1,4 @@
 document.addEventListener('WebComponentsReady', () => {
-  function getBodyCellTextAsString(grid, row, cell) {
-    const value = getBodyCellText(grid, row, cell);
-    return (value + '').trim();
-  }
-
   describe('number renderer', () => {
     let grid;
     let _consoleErrorOriginal = null;

--- a/test/row-details.js
+++ b/test/row-details.js
@@ -15,6 +15,7 @@ document.addEventListener('WebComponentsReady', () => {
 
     it('should open and close row with setRowDetailsVisible(item)', (done) => {
       grid.setRowDetailsVisible(grid.tableData[0], true);
+
       setTimeout(() => {
         const rowDetails = getRows(grid)[0].querySelector('td:last-child');
         expect(rowDetails.hasAttribute('aria-expanded')).to.be.true;
@@ -25,8 +26,8 @@ document.addEventListener('WebComponentsReady', () => {
           const rowDetails = getRows(grid)[0].querySelector('td:last-child');
           expect(rowDetails.hidden).to.be.true;
           done();
-        }, 50);
-      }, 50);
+        }, 100);
+      }, 100);
     });
 
   });

--- a/test/timezones.js
+++ b/test/timezones.js
@@ -24,8 +24,8 @@ document.addEventListener('WebComponentsReady', () => {
     it('should convert to defined timezone', () => {
       // format: YYYY-MM-DD HH:mm:ss -> MM/DD/YYYY HH:mm:ss
       // timezone: UTC -> PST
-      expect(getBodyCellText(grid, 0, 3)).to.equal('05/19/2005 17:00:00'); // -7 (daylights savings)
-      expect(getBodyCellText(grid, 4, 3)).to.equal('12/20/2010 02:30:00'); // -8
+      expect(getBodyCellTextAsString(grid, 0, 3)).to.equal('05/19/2005 17:00:00'); // -7 (daylights savings)
+      expect(getBodyCellTextAsString(grid, 4, 3)).to.equal('12/20/2010 02:30:00'); // -8
     });
 
     it('should sort by timestamp ASC', () => {

--- a/test/timezones.js
+++ b/test/timezones.js
@@ -1,0 +1,52 @@
+document.addEventListener('WebComponentsReady', () => {
+  describe('timezones', () => {
+    let grid;
+    let firstNameHeaderCell;
+    let lastNameHeaderCell;
+    let timestampHeaderCell;
+
+
+    beforeEach((done) => {
+      grid = fixture('px-data-grid-fixture');
+      grid.columns = getColumnConfig();
+      grid.tableData = tableData;
+
+      Polymer.RenderStatus.afterNextRender(grid, () => {
+        setTimeout(() => { // IE11
+          firstNameHeaderCell = getHeaderCell(grid, 0);
+          lastNameHeaderCell = getHeaderCell(grid, 1);
+          timestampHeaderCell = getHeaderCell(grid, 3);
+          window.flush(done);
+        });
+      });
+    });
+
+    it('should convert to defined timezone', () => {
+      // format: YYYY-MM-DD HH:mm:ss -> MM/DD/YYYY HH:mm:ss
+      // timezone: UTC -> PST
+      expect(getBodyCellText(grid, 0, 3)).to.equal('05/19/2005 17:00:00'); // -7 (daylights savings)
+      expect(getBodyCellText(grid, 4, 3)).to.equal('12/20/2010 02:30:00'); // -8
+    });
+
+    it('should sort by timestamp ASC', () => {
+      const sorter = getHeaderCellContent(timestampHeaderCell).querySelector('px-data-grid-sorter');
+      sorter.click();
+      expect(getBodyCellContent(grid, 0, 0)).to.equal('Elizabeth');
+      expect(getBodyCellContent(grid, 1, 0)).to.equal('Alma');
+      expect(getBodyCellContent(grid, 2, 0)).to.equal('Jeffrey');
+      expect(getBodyCellContent(grid, 3, 0)).to.equal('Elizabeth');
+      expect(getBodyCellContent(grid, 4, 0)).to.equal('Willie');
+    });
+
+    it('should sort by timestamp DESC', () => {
+      const sorter = getHeaderCellContent(timestampHeaderCell).querySelector('px-data-grid-sorter');
+      sorter.click();
+      sorter.click();
+      expect(getBodyCellContent(grid, 0, 0)).to.equal('Willie');
+      expect(getBodyCellContent(grid, 1, 0)).to.equal('Elizabeth');
+      expect(getBodyCellContent(grid, 2, 0)).to.equal('Jeffrey');
+      expect(getBodyCellContent(grid, 3, 0)).to.equal('Alma');
+      expect(getBodyCellContent(grid, 4, 0)).to.equal('Elizabeth');
+    });
+  });
+});


### PR DESCRIPTION
Adding timezone support to px-data-grid.  The application can now specify what timezone the column's data is in, as well as what timezone to display it as.  All existing features such as editing, sorting, and filtering support this.  Anything timestamp/date that is visible will use the display timezone (instead of the data's original timezone).  The underlying data is always kept in the original timezone and format.

Example of a date column with timezones specified:
```
{
  name: 'Appointment',
  path: 'appointment',
  filterByTime: true,
  renderer: 'px-data-grid-date-renderer',
  dateFormat: {
    format: 'YYYY-MM-DD HH:mm',
    timezone: 'UTC' // data's timezone
  },
  rendererConfig: {
    hideTime: false,
    displayFormat: 'MM/DD/YYYY HH:mm',
    timezone: 'America/Los_Angeles', // timezone to be shown
    datePickerDateFormat: 'MM/DD/YYYY',
    datePickerTimeFormat: 'HH:mm'
  },
  editable: true,
  type: 'date'
}
```