### PR TITLE
Add use-timezones boolean property to toggle timezones in advanced filtering

### DIFF
--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -54,7 +54,7 @@
             date-format="YYYY/MM/DD"
             time-format="HH:mm:ss"
             time-zone="UTC"
-            show-time-zone="abbreviatedText"
+            show-time-zone="[[_showTimeZone]]"
             show-field-titles
             from-moment="{{_dateFrom}}"
             to-moment="{{_dateTo}}"
@@ -173,6 +173,15 @@
               type: Array
             },
 
+            useTimezones: {
+              type: Boolean
+            },
+
+            _showTimeZone: {
+              type: String,
+              value: 'none'
+            },
+
             _mappedColumns: Array,
 
             _regexPatterns: {
@@ -264,6 +273,7 @@
             '_momentDatesObserver(_dateFrom, _dateTo, _dateFrom.*, _dateTo.*)',
             // '_entityDatesObserver(entity, entity.dateFrom, entity.dateTo)',
             '_localizeChanged(localize)',
+            '_useTimezonesChanged(useTimezones)',
             '_entityObserver(entity, entity.*)',
             '_columnNumberBoundsObserver(entity, entity.columnId, columns.*)',
             '_setDateRanges(entity, columns, entity.columnId, columns.*)',
@@ -283,6 +293,10 @@
           this._numberConditions.forEach((condition, index) => {
             this.set(`_numberConditions.${index}.val`, localize(condition.val));
           });
+        }
+
+        _useTimezonesChanged(useTimezones) {
+          this._showTimeZone = useTimezones ? 'dropdown' : 'none';
         }
 
         _setDateRanges(entity, columns) {

--- a/px-data-grid-filter-section.html
+++ b/px-data-grid-filter-section.html
@@ -41,6 +41,7 @@
           compact-mode="[[_isEntityCompact(_compactModeEnabled, index)]]"
           string-comparators="[[stringComparators]]"
           number-comparators="[[numberComparators]]"
+          use-timezones="[[useTimezones]]"
           localize="[[localize]]">
         </px-data-grid-filter-entity>
         <div class="actionable" on-click="_removeEntity">
@@ -118,6 +119,10 @@
 
             numberComparators: {
               type: Array
+            },
+
+            useTimezones: {
+              type: Boolean
             },
 
             _compactModeEnabled: {

--- a/px-data-grid-filter.html
+++ b/px-data-grid-filter.html
@@ -14,6 +14,7 @@
         compact-mode="[[compactMode]]"
         string-comparators="[[stringComparators]]"
         number-comparators="[[numberComparators]]"
+        use-timezones="[[useTimezones]]"
         localize="[[localize]]">
       </px-data-grid-filter-section>
     </template>
@@ -62,6 +63,10 @@
 
             numberComparators: {
               type: Array
+            },
+
+            useTimezones: {
+              type: Boolean
             },
 
             localize: Function

--- a/px-data-grid-filters-modal.html
+++ b/px-data-grid-filters-modal.html
@@ -22,6 +22,7 @@
           compact-mode="[[compactMode]]"
           string-comparators="[[stringComparators]]"
           number-comparators="[[numberComparators]]"
+          use-timezones="[[useTimezones]]"
           localize="[[localize]]">
         </px-data-grid-filter>
 
@@ -87,6 +88,10 @@
 
             numberComparators: {
               type: Array
+            },
+
+            useTimezones: {
+              type: Boolean
             },
 
             _tempFilters: {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -54,7 +54,8 @@
               initial-filter-state="[[_initialFilterState]]"
               compact-mode="[[compactAdvancedFilterDialog]]"
               string-comparators="[[stringComparators]]"
-              number-comparators="[[numberComparators]]">
+              number-comparators="[[numberComparators]]"
+              use-timezones="[[useTimezones]]">
             </px-data-grid-filters-modal>
           </template>
 
@@ -1136,6 +1137,14 @@
              */
             stringComparators: {
               type: Array
+            },
+
+            /**
+             * Set to `true` to be able to change timezones in the advanced filtering modal.
+             */
+            useTimezones: {
+              type: Boolean,
+              value: true
             },
 
             /**


### PR DESCRIPTION
Depends on https://github.com/predixdesignsystem/px-datetime-common/pull/19 which fix this overflow issue with the timezone dropdown:

![image](https://user-images.githubusercontent.com/6059356/37334953-fe6b4c92-26b5-11e8-9e5b-f28939189cbd.png)