### PR TITLE
Use rendererConfig.displayFormat for datetime-pickers

### DIFF
--- a/demo/px-data-grid-date-and-time-demo.html
+++ b/demo/px-data-grid-date-and-time-demo.html
@@ -184,8 +184,7 @@
             rendererConfig: {
               hideTime: true,
               displayFormat: 'DD-MM-YY',
-              dataFormat: 'YYYY-MM-DD',
-              datePickerDateFormat: 'DD-MM-YY',
+              dataFormat: 'YYYY-MM-DD'
             },
           },
           {
@@ -198,9 +197,7 @@
             rendererConfig: {
               hideTime: false,
               displayFormat: 'DD-MM-YY HH:MM',
-              dataFormat: 'ISO',
-              datePickerDateFormat: 'DD-MM-YY',
-              datePickerTimeFormat: 'HH:MM'
+              dataFormat: 'ISO'
             },
           }
         ],

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -234,16 +234,10 @@ Make date-renderer columns use ellipsis overflow:
             this.dataFormat = 'YYYY-MM-DD';
           }
 
-          if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('datePickerDateFormat')) {
-            this.datePickerDateFormat = rendererConfig.value.datePickerDateFormat;
-          } else {
-            this.datePickerDateFormat = 'YYYY-MM-DD';
-          }
-
-          if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('datePickerTimeFormat')) {
-            this.datePickerTimeFormat = rendererConfig.value.datePickerTimeFormat;
-          } else {
-            this.datePickerTimeFormat = 'HH:MM:SS';
+          if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('displayFormat')) {
+            const [date, time] = rendererConfig.value.displayFormat.split(' ');
+            this.datePickerDateFormat = date ? date : 'YYYY-MM-DD';
+            this.datePickerTimeFormat = time ? time : 'HH:MM:SS';
           }
 
         }

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -387,14 +387,6 @@
              *   * `{string} rendererConfig.dataFormat='YYYY-MM-DD'` - Format
              *     the grid expects data in when reading it from `tableData`.
              *
-             *   * `{string} rendererConfig.datePickerDateFormat='YYYY-MM-DD'` -
-             *     Format used for the px-datetime-picker date when the user
-             *     edits cells in the column.
-             *
-             *   * `{string} rendererConfig.datePickerTimeFormat='HH:MM:SS'` -
-             *     Format used for the px-datetime-picker time when the user
-             *     edits cells in the column.
-             *
              *   * `{boolean} rendererConfig.hideDate=false` - Hides the date
              *     section of the px-datetime-picker when the user edits cells
              *     in the column.

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -508,14 +508,6 @@
              *   * `{string} rendererConfig.dataFormat='YYYY-MM-DD'` - Format
              *     the grid expects data in when reading it from `tableData`.
              *
-             *   * `{string} rendererConfig.datePickerDateFormat='YYYY-MM-DD'` -
-             *     Format used for the px-datetime-picker date when the user
-             *     edits cells in the column.
-             *
-             *   * `{string} rendererConfig.datePickerTimeFormat='HH:MM:SS'` -
-             *     Format used for the px-datetime-picker time when the user
-             *     edits cells in the column.
-             *
              *   * `{boolean} rendererConfig.hideDate=false` - Hides the date
              *     section of the px-datetime-picker when the user edits cells
              *     in the column.


### PR DESCRIPTION
Fixes #756

Use `rendererConfig.displayFormat` for datetime-pickers, drop `rendererConfig.datePickerDateFormat` and `rendererConfig.datePickerTimeFormat`