### PR TITLE
Pass item to renderer, add item property to renderer mixin

### DIFF
--- a/px-data-grid-cell-content-wrapper.html
+++ b/px-data-grid-cell-content-wrapper.html
@@ -162,6 +162,7 @@
             this._valueElement.initialValue = value;
             this._valueElement.editable = editable;
             this._valueElement.localize = localize;
+            this._valueElement.item = item;
           } else {
             this.shadowRoot.textContent = value;
           }

--- a/px-data-grid-renderer-mixin.html
+++ b/px-data-grid-renderer-mixin.html
@@ -31,6 +31,10 @@
           type: Object
         },
 
+        item: {
+          type: Object
+        },
+
         /**
          * Boolean to pair with validation error element visibility
          */


### PR DESCRIPTION
Passes the tableData item aka row to the renderer mixin, so renderers can know things about the object used to create them.

Useful for examples like this, a button that when clicked fires a custom event with its item:

```html
<dom-module id="custom-button-renderer">
  <template>
    <button on-click="_onClick">
      Register User
    </button>
  </template>
  <script>
    {
      class CustomButtonRenderer extends Predix.DataGridRendererMixin(Polymer.Element) {
        static get is() { return 'custom-button-renderer'; }
        
        static get properties() {
          return {};
        }
        
        _onClick() {
          const { column, item, value } = this;
          const e = new CustomEvent('custom-button-cell-clicked', {
            detail: { column, item, value },
            bubbles: true,
            composed: true
          });
          this.dispatchEvent(e);
        }
        
      }
      window.customElements.define(CustomButtonRenderer.is, CustomButtonRenderer);
    }
  </script>
</dom-module>
```