### PR TITLE
Add showTimeZone prop to column config

### DIFF
--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -592,16 +592,17 @@
           format: 'YYYY-MM-DD HH:mm',
           timezone: 'UTC'
         },
-        filterByTime: true,
         renderer: 'px-data-grid-date-renderer',
         rendererConfig: {
           hideTime: false,
           displayFormat: 'MM/DD/YYYY HH:mm',
           timezone: 'America/Los_Angeles',
-          datePickerDateFormat: 'MM/DD/YYYY',
+          showTimeZone: 'abbreviatedText',
+          datePickerDateFormat: 'MM-DD/YYYY',
           datePickerTimeFormat: 'HH:mm'
         },
         editable: true,
+        filterByTime: true,
         type: 'date'
       }
     ];

--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -41,7 +41,7 @@ Make date-renderer columns use ellipsis overflow:
           hide-time="[[hideTime]]"
           hide-date="[[hideDate]]"
           time-zone="[[displayTimezone]]"
-          show-time-zone="abbreviatedText"
+          show-time-zone="[[showTimeZone]]"
           date-format="[[datePickerDateFormat]]"
           time-format="[[datePickerTimeFormat]]"
           hoist>
@@ -92,6 +92,20 @@ Make date-renderer columns use ellipsis overflow:
             timezone: {
               type: String,
               value: 'UTC'
+            },
+            /**
+             * String representing how to show timezones. Valid values
+             * come from the px-datetime-picker component.
+             *
+             * `none`: do not show timezone
+             * `text`: show timezone as non-editable text
+             * `abbreviatedText`: shows abbreviated version of timezone as non-editable text
+             * `dropdown`: show timezone in dropdown that contains common offset values
+             * `extendedDropdown`: show timezone in dropdown and includes all timezones
+             */
+            showTimeZone: {
+              type: String,
+              value: 'none'
             },
             /**
              * Format for px-datepicker's dateFormat
@@ -271,6 +285,11 @@ Make date-renderer columns use ellipsis overflow:
             this.datePickerTimeFormat = 'HH:MM:SS';
           }
 
+          if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('datePickerTimeFormat')) {
+            this.showTimeZone = rendererConfig.value.showTimeZone;
+          } else {
+            this.showTimeZone = 'none';
+          }
         }
       }
 

--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -173,13 +173,16 @@
               type: Array
             },
 
-            useTimezones: {
+            _hideTimezone: {
+              type: Boolean
+            },
+
+            _editableTimezone: {
               type: Boolean
             },
 
             _showTimeZone: {
-              type: String,
-              value: 'none'
+              type: String
             },
 
             _mappedColumns: Array,
@@ -289,7 +292,6 @@
             '_momentDatesObserver(_dateFrom, _dateTo, _dateFrom.*, _dateTo.*)',
             // '_entityDatesObserver(entity, entity.dateFrom, entity.dateTo)',
             '_localizeChanged(localize)',
-            '_useTimezonesChanged(useTimezones)',
             '_entityObserver(entity, entity.*)',
             '_columnNumberBoundsObserver(entity, entity.columnId, columns.*)',
             '_setDateRanges(entity, columns, entity.columnId, columns.*)',
@@ -309,10 +311,6 @@
           this._numberConditions.forEach((condition, index) => {
             this.set(`_numberConditions.${index}.val`, localize(condition.val));
           });
-        }
-
-        _useTimezonesChanged(useTimezones) {
-          this._showTimeZone = useTimezones ? 'dropdown' : 'none';
         }
 
         _setDateRanges(entity, columns) {
@@ -359,6 +357,8 @@
             this.set('_displayDateFormat', selectedColumn.rendererConfig.datePickerDateFormat || 'YYYY/MM/DD');
             this.set('_displayTimeFormat', selectedColumn.rendererConfig.datePickerTimeFormat || 'HH:mm');
             this.set('_displayTimezone', selectedColumn.rendererConfig.timezone || 'UTC');
+            // showTimeZone prop uses values from px-datetime-picker's showTimeZone prop
+            this.set('_showTimeZone', selectedColumn.rendererConfig.showTimeZone || 'none');
           }
         }
 

--- a/px-data-grid-filter-section.html
+++ b/px-data-grid-filter-section.html
@@ -41,7 +41,6 @@
           compact-mode="[[_isEntityCompact(_compactModeEnabled, index)]]"
           string-comparators="[[stringComparators]]"
           number-comparators="[[numberComparators]]"
-          use-timezones="[[useTimezones]]"
           localize="[[localize]]">
         </px-data-grid-filter-entity>
         <div class="actionable" on-click="_removeEntity">
@@ -119,10 +118,6 @@
 
             numberComparators: {
               type: Array
-            },
-
-            useTimezones: {
-              type: Boolean
             },
 
             _compactModeEnabled: {


### PR DESCRIPTION
Adds `showTimeZone` property to the column config object.  This property directly maps into the px-datetime-picker used by the advanced filtering dialog and the date renderer in edit mode.

![edit-row-timezone](https://user-images.githubusercontent.com/2496955/37539755-d5e0d25c-2911-11e8-8d61-2899acebc38b.jpg)

![filtering-timezone](https://user-images.githubusercontent.com/2496955/37540059-f3fa8188-2912-11e8-885d-480b54d1e56e.jpg)

You can see the list of acceptable values by looking at the px-datetime-picker’s `showTimeZone` property: https://www.predix-ui.com/#/elements/datetime/px-datetime-picker



