### PR TITLE
Setting defaults to show non-editable timezone

### DIFF
--- a/px-data-grid-date-renderer.html
+++ b/px-data-grid-date-renderer.html
@@ -250,7 +250,7 @@ Make date-renderer columns use ellipsis overflow:
           if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('displayFormat')) {
             this.displayFormat = rendererConfig.value.displayFormat;
           } else {
-            this.displayFormat = 'YYYY-MM-DD';
+            this.displayFormat = 'YYYY-MM-DD z';
           }
 
           if (rendererConfig && rendererConfig.value && rendererConfig.value.hasOwnProperty('timezone')) {

--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -54,7 +54,7 @@
             date-format="YYYY/MM/DD"
             time-format="HH:mm:ss"
             time-zone="[[_displayTimezone]]"
-            show-time-zone="[[_showTimeZone]]"
+            show-time-zone="abbreviatedText"
             show-field-titles
             from-moment="{{_dateFrom}}"
             to-moment="{{_dateTo}}"
@@ -173,15 +173,6 @@
               type: Array
             },
 
-            useTimezones: {
-              type: Boolean
-            },
-
-            _showTimeZone: {
-              type: String,
-              value: 'none'
-            },
-
             _mappedColumns: Array,
 
             _regexPatterns: {
@@ -289,7 +280,6 @@
             '_momentDatesObserver(_dateFrom, _dateTo, _dateFrom.*, _dateTo.*)',
             // '_entityDatesObserver(entity, entity.dateFrom, entity.dateTo)',
             '_localizeChanged(localize)',
-            '_useTimezonesChanged(useTimezones)',
             '_entityObserver(entity, entity.*)',
             '_columnNumberBoundsObserver(entity, entity.columnId, columns.*)',
             '_setDateRanges(entity, columns, entity.columnId, columns.*)',
@@ -309,10 +299,6 @@
           this._numberConditions.forEach((condition, index) => {
             this.set(`_numberConditions.${index}.val`, localize(condition.val));
           });
-        }
-
-        _useTimezonesChanged(useTimezones) {
-          this._showTimeZone = useTimezones ? 'dropdown' : 'none';
         }
 
         _setDateRanges(entity, columns) {

--- a/px-data-grid-filter-section.html
+++ b/px-data-grid-filter-section.html
@@ -41,7 +41,6 @@
           compact-mode="[[_isEntityCompact(_compactModeEnabled, index)]]"
           string-comparators="[[stringComparators]]"
           number-comparators="[[numberComparators]]"
-          use-timezones="[[useTimezones]]"
           localize="[[localize]]">
         </px-data-grid-filter-entity>
         <div class="actionable" on-click="_removeEntity">
@@ -119,10 +118,6 @@
 
             numberComparators: {
               type: Array
-            },
-
-            useTimezones: {
-              type: Boolean
             },
 
             _compactModeEnabled: {

--- a/px-data-grid-filter.html
+++ b/px-data-grid-filter.html
@@ -14,7 +14,6 @@
         compact-mode="[[compactMode]]"
         string-comparators="[[stringComparators]]"
         number-comparators="[[numberComparators]]"
-        use-timezones="[[useTimezones]]"
         localize="[[localize]]">
       </px-data-grid-filter-section>
     </template>
@@ -63,10 +62,6 @@
 
             numberComparators: {
               type: Array
-            },
-
-            useTimezones: {
-              type: Boolean
             },
 
             localize: Function

--- a/px-data-grid-filters-modal.html
+++ b/px-data-grid-filters-modal.html
@@ -22,7 +22,6 @@
           compact-mode="[[compactMode]]"
           string-comparators="[[stringComparators]]"
           number-comparators="[[numberComparators]]"
-          use-timezones="[[useTimezones]]"
           localize="[[localize]]">
         </px-data-grid-filter>
 
@@ -88,10 +87,6 @@
 
             numberComparators: {
               type: Array
-            },
-
-            useTimezones: {
-              type: Boolean
             },
 
             _tempFilters: {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -54,8 +54,7 @@
               initial-filter-state="[[_initialFilterState]]"
               compact-mode="[[compactAdvancedFilterDialog]]"
               string-comparators="[[stringComparators]]"
-              number-comparators="[[numberComparators]]"
-              use-timezones="[[useTimezones]]">
+              number-comparators="[[numberComparators]]">
             </px-data-grid-filters-modal>
           </template>
 
@@ -1142,14 +1141,6 @@
              */
             stringComparators: {
               type: Array
-            },
-
-            /**
-             * Set to `true` to be able to change timezones in the advanced filtering modal.
-             */
-            useTimezones: {
-              type: Boolean,
-              value: true
             },
 
             /**


### PR DESCRIPTION
 * Date renderer now defaults to include time zone (short hand).
 * Date render in edit mode show time zone but does not allow user to edit it.
 * Advanced filtering dialog shows time zone but does not allow user to edit it.
