### PR TITLE
Mapping date and time formats to filter dialog range picker

### DIFF
--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -51,8 +51,8 @@
             id="date-rangepicker"
             hide-time="[[_hideTime]]"
             hide-presets
-            date-format="YYYY/MM/DD"
-            time-format="HH:mm:ss"
+            date-format="[[_datePickerDateFormat]]"
+            time-format="[[_datePickerTimeFormat]]"
             time-zone="[[_displayTimezone]]"
             show-time-zone="[[_showTimeZone]]"
             show-field-titles
@@ -278,6 +278,14 @@
               type: String
             },
 
+            _datePickerDateFormat: {
+              type: String
+            },
+
+            _datePickerTimeFormat: {
+              type: String
+            },
+
             localize: Function
           };
         }
@@ -359,6 +367,8 @@
             this.set('_displayDateFormat', selectedColumn.rendererConfig.datePickerDateFormat || 'YYYY/MM/DD');
             this.set('_displayTimeFormat', selectedColumn.rendererConfig.datePickerTimeFormat || 'HH:mm');
             this.set('_displayTimezone', selectedColumn.rendererConfig.timezone || 'UTC');
+            this.set('_datePickerDateFormat', selectedColumn.rendererConfig.datePickerDateFormat || 'YYYY/MM/DD');
+            this.set('_datePickerTimeFormat', selectedColumn.rendererConfig.datePickerTimeFormat || 'HH:mm');
           }
         }
 


### PR DESCRIPTION
Column `rendererConfig` object contains two props:
 * `datePickerDateFormat`
 * `datePickerTimeFormat`

These two properties now get applied to the `px-rangepicker` in the filter dialog.