### PR TITLE
Unfroze row action column.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/predixdesignsystem/px-data-grid",
   "main": "px-data-grid.html",
   "description": "Polymer 2 element that displays tabular data",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Polymer 2 element that defines a data grid (data table)",
   "main": "px-data-grid.html",
   "repository": "predixdesignsystem/px-data-grid",

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -186,7 +186,7 @@ limitations under the License.
         </px-data-grid-column>
       </template>
 
-      <vaadin-grid-column-group frozen>
+      <vaadin-grid-column-group>
         <template is="dom-if" if="[[_offerEditColumn(editable)]]" restamp>
           <px-data-grid-edit-column
             editted-item="[[_editingItem]]"


### PR DESCRIPTION
Workaround for an infinite scrolling bug on grids which occurs when the sum of all column width exceeds the containing element width.

**Before:**
![px-data-grid-infinite-scroll-bug](https://user-images.githubusercontent.com/30222239/42690631-5660c5d4-86e8-11e8-89bd-7f9fc8b215e4.gif)

**After:**
![px-data-grid-infinite-scroll-fixed](https://user-images.githubusercontent.com/30222239/42690687-9ed025d0-86e8-11e8-9d31-274f114a6ab5.gif)
