### PR TITLE
Bumping to 1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: latest
+  firefox: 60.0
   google-chrome: latest
 
 install:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "https://github.com/predixdesignsystem/px-data-grid",
   "main": "px-data-grid.html",
   "description": "Polymer 2 element that displays tabular data",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Polymer 2 element that defines a data grid (data table)",
   "main": "px-data-grid.html",
   "repository": "predixdesignsystem/px-data-grid",


### PR DESCRIPTION
Fix #801 bumped the version number in bower.json and package.json to 1.0.3 - however this version number had already been released by @sks (without updating either of those files).

This bumps the version to 1.0.4 which will now be used to release the fix in #801.