### PR TITLE
Columns can take default sorting

### DIFF
--- a/px-data-grid-sorter.html
+++ b/px-data-grid-sorter.html
@@ -46,6 +46,18 @@ limitations under the License.
             */
             path: String,
 
+
+            /**
+            * Optional default sort order for the column, increasing from 0.
+            */
+            defaultSortOrder: Number,
+
+            /**
+            * Optional default sort direction for the column, see direction property
+            * for appropriate values.
+            */
+            defaultSortDirection: String,
+
             /**
             * How to sort the data.
             * Possible values are `asc` to use an ascending algorithm, `desc` to sort the data in
@@ -84,7 +96,9 @@ limitations under the License.
 
         connectedCallback() {
           super.connectedCallback();
+          this.direction = this.defaultSortDirection || null;
           this._isConnected = true;
+          this.order = this.defaultSortOrder || null;
         }
 
         disconnectedCallback() {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -144,7 +144,12 @@ limitations under the License.
           group-by-column-allowed="[[_groupByColumnAllowed(_hasLocalDataProvider, _expandableRows)]]"
           is-data-column="true">
           <template class="header">
-            <px-data-grid-sorter path="[[_resolveColumnPath(column)]]">[[resolveColumnHeader(column)]]</px-data-grid-sorter>
+            <px-data-grid-sorter
+              path="[[_resolveColumnPath(column)]]"
+              default-sort-order="[[column.defaultSortOrder]]"
+              default-sort-direction="[[column.defaultSortDirection]]">
+              [[resolveColumnHeader(column)]]
+            </px-data-grid-sorter>
           </template>
 
           <template>

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -2202,13 +2202,16 @@ limitations under the License.
 
             this._sorters.forEach((sorter, index) => sorter._order = this._sorters.length > 1 ? index : null, this);
           } else {
-            this._sorters.forEach(sorter => {
-              sorter._order = null;
-              sorter.direction = null;
-            });
-
+            const others = this._sorters.filter(s => s != sorter);
             if (sorter.direction) {
+              others.forEach(sorter => {
+                sorter._order = null;
+                sorter.direction = null;
+              });
+
               this._sorters = [sorter];
+            } else {
+              this._sorters = others;
             }
           }
 


### PR DESCRIPTION
Enables default sorting by setting `column.defaultSortOrder` and `column.defaultSortDirection`.

If the properties are not specified, there is no change:
![nodefaultsortorderdeclared](https://user-images.githubusercontent.com/5815812/44294686-ec936980-a24f-11e8-8479-ee27b4276009.png)

In `single-sort` tables,
set `column.defaultSortDirection = "asc" or "desc"` to enable default sorting:
![defaultsortordersingle](https://user-images.githubusercontent.com/5815812/44294694-164c9080-a250-11e8-8923-70100478749b.png)

In `multi-sort` tables, 
set `column.defaultSortDirection = "asc" or "desc"` and 
set `column.defaultSortOrder = 1..n` to specify the sort priorities:
![defaultsortorder](https://user-images.githubusercontent.com/5815812/44294692-092fa180-a250-11e8-937d-2e1c684ed39b.png)

This only changes initial sort order. Users can still change the sort behavior as before.