### PR TITLE
Added the code to set the required height to vaadin-grid

### DIFF
--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -1294,6 +1294,10 @@ limitations under the License.
           this._vaadinGrid._pxDataGrid = this;
           this._vaadinGrid.addEventListener('px-sorter-changed', this._onPxSorterChanged);
 
+          if (this.gridHeight != 'auto') {
+            this._vaadinGrid.style.maxHeight = this.gridHeight;
+          }
+          
           // Attach scroll listener for styling
           this._boundedScrollListener = this._scrollListener.bind(this);
           this._vaadinGrid.$.outerscroller.addEventListener('scroll', this._boundedScrollListener);


### PR DESCRIPTION
The height: auto of vaadin-grid is not working properly in firefox. Please see the below screen for reference.
![image](https://user-images.githubusercontent.com/3511261/45087457-7df54d80-b123-11e8-8668-a039f3c07c9e.png)

If I want to set my specific height to that vaadin-grid by passing gridHeight parameter, Currently it is not being set to our specific height. By default 400px is being set as per the css which is mentioned in vaadin-grid component.

Now here we are enabling to set the our required height to vaadin-grid when the gridHeight is passed from my application (PETC).