### PR TITLE
Single-select removal

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v1.0.7
+==========================
+Bug fixes:
+* #808 - selected-items-changed event behaves consistently
+
 v1.0.6
 ==========================
 Enhancement:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "homepage": "https://github.com/predixdesignsystem/px-data-grid",
   "main": "px-data-grid.html",
   "description": "Polymer 2 element that displays tabular data",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@polymer/sinonjs": {
       "version": "1.17.1",
@@ -14104,6 +14103,15 @@
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -14119,15 +14127,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-data-grid",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Polymer 2 element that defines a data grid (data table)",
   "main": "px-data-grid.html",
   "repository": "predixdesignsystem/px-data-grid",

--- a/px-data-grid-api.json
+++ b/px-data-grid-api.json
@@ -1274,7 +1274,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridColumnElement",
           "attributes": [
             {
@@ -1501,11 +1501,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -1524,11 +1524,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -1547,11 +1547,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -1570,11 +1570,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -1593,11 +1593,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -1616,11 +1616,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -1639,11 +1639,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -1662,11 +1662,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -1685,11 +1685,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -1708,11 +1708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -1731,11 +1731,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -1754,11 +1754,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -1777,11 +1777,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -1800,11 +1800,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -1823,11 +1823,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -1846,11 +1846,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -1869,11 +1869,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -1892,11 +1892,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -1915,11 +1915,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -1938,11 +1938,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -1961,11 +1961,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -1984,11 +1984,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -2007,11 +2007,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -2024,17 +2024,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -2053,11 +2053,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -2138,11 +2138,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -2261,7 +2261,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -2378,11 +2378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -2400,11 +2400,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -2733,11 +2733,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -2757,6 +2757,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -2771,11 +2776,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -2809,11 +2814,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -2847,11 +2852,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -2885,11 +2890,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -2902,7 +2907,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -2914,11 +2919,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -2948,11 +2953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -2976,11 +2981,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -3009,11 +3014,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -3038,11 +3043,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -3067,11 +3072,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -3105,11 +3110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -3143,11 +3148,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -3177,11 +3182,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -3206,11 +3211,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -3235,11 +3240,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -3264,11 +3269,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -3293,11 +3298,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -3305,7 +3310,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -3337,11 +3342,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -3375,11 +3380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -3403,11 +3408,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -3425,11 +3430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -3444,11 +3449,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -3466,11 +3471,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -3499,11 +3504,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -3537,11 +3542,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -3549,12 +3554,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -3570,11 +3575,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -3582,7 +3587,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -3598,11 +3603,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -3631,11 +3636,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -3643,7 +3648,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -3665,11 +3670,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -3677,7 +3682,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -3703,11 +3708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -3715,7 +3720,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -3738,11 +3743,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -3750,7 +3755,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -3767,11 +3772,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -3779,7 +3784,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -3812,11 +3817,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -3824,7 +3829,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -3841,11 +3846,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -3853,7 +3858,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -3876,11 +3881,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -3909,11 +3914,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -3942,11 +3947,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -3959,7 +3964,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -3980,11 +3985,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -3997,7 +4002,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -4013,11 +4018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -4041,11 +4046,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -4069,11 +4074,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -4091,7 +4096,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -4107,11 +4112,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -4141,11 +4146,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -4169,11 +4174,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -4191,11 +4196,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -4213,11 +4218,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -4242,11 +4247,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -4270,11 +4275,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -4357,11 +4362,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -4386,11 +4391,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -4463,11 +4468,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -4541,11 +4546,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -4619,11 +4624,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -4674,11 +4679,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -4703,11 +4708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -4725,11 +4730,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -4763,11 +4768,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -4780,7 +4785,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -4801,11 +4806,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -4818,7 +4823,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -4835,11 +4840,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -4863,11 +4868,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -4896,11 +4901,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -4924,11 +4929,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -4946,7 +4951,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -4962,11 +4967,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -4991,11 +4996,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -5024,16 +5029,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -5063,11 +5068,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -5117,11 +5122,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -5139,11 +5144,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -5161,11 +5166,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -5194,11 +5199,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -5228,11 +5233,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -5263,7 +5268,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.AutoFilterFieldElement",
           "attributes": [
             {
@@ -5343,11 +5348,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -5366,11 +5371,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -5389,11 +5394,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -5412,11 +5417,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -5435,11 +5440,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -5458,11 +5463,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -5481,11 +5486,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -5504,11 +5509,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -5527,11 +5532,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -5550,11 +5555,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -5573,11 +5578,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -5596,11 +5601,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -5619,11 +5624,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -5642,11 +5647,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -5665,11 +5670,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -5688,11 +5693,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -5711,11 +5716,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -5734,11 +5739,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -5757,11 +5762,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -5780,11 +5785,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -5803,11 +5808,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -5826,11 +5831,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -5849,11 +5854,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -5866,17 +5871,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -5895,11 +5900,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -6018,11 +6023,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -6141,7 +6146,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -6258,11 +6263,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -6280,11 +6285,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -6613,11 +6618,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -6637,6 +6642,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -6651,11 +6661,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -6689,11 +6699,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -6727,11 +6737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -6765,11 +6775,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -6782,7 +6792,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -6794,11 +6804,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -6828,11 +6838,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -6856,11 +6866,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -6889,11 +6899,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -6918,11 +6928,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -6947,11 +6957,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -6985,11 +6995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -7023,11 +7033,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -7057,11 +7067,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -7086,11 +7096,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -7115,11 +7125,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -7144,11 +7154,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -7173,11 +7183,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -7185,7 +7195,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -7217,11 +7227,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -7255,11 +7265,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -7283,11 +7293,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -7305,11 +7315,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -7324,11 +7334,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -7346,11 +7356,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -7379,11 +7389,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -7417,11 +7427,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -7429,12 +7439,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -7450,11 +7460,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -7462,7 +7472,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -7478,11 +7488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -7511,11 +7521,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -7523,7 +7533,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -7545,11 +7555,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -7557,7 +7567,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -7583,11 +7593,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -7595,7 +7605,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -7618,11 +7628,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -7630,7 +7640,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -7647,11 +7657,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -7659,7 +7669,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -7692,11 +7702,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -7704,7 +7714,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -7721,11 +7731,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -7733,7 +7743,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -7756,11 +7766,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -7789,11 +7799,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -7822,11 +7832,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -7839,7 +7849,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -7860,11 +7870,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -7877,7 +7887,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -7893,11 +7903,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -7921,11 +7931,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -7949,11 +7959,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -7971,7 +7981,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -7987,11 +7997,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -8021,11 +8031,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -8049,11 +8059,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -8071,11 +8081,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -8093,11 +8103,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -8122,11 +8132,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -8150,11 +8160,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -8241,11 +8251,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -8270,11 +8280,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -8347,11 +8357,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -8425,11 +8435,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -8503,11 +8513,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -8558,11 +8568,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -8587,11 +8597,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -8609,11 +8619,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -8647,11 +8657,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -8664,7 +8674,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -8685,11 +8695,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -8702,7 +8712,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -8719,11 +8729,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -8747,11 +8757,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -8780,11 +8790,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -8808,11 +8818,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -8830,7 +8840,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -8846,11 +8856,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -8875,11 +8885,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -8908,16 +8918,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -8947,11 +8957,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -9001,11 +9011,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -9023,11 +9033,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -9045,11 +9055,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -9078,11 +9088,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -9112,11 +9122,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -9147,7 +9157,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridSelectAllElement",
           "attributes": [
             {
@@ -10539,7 +10549,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridSelectionColumnElement",
           "attributes": [
             {
@@ -11714,7 +11724,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridToggleDetailsColumnElement",
           "attributes": [
             {
@@ -11844,11 +11854,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -11867,11 +11877,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -11890,11 +11900,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -11913,11 +11923,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -11936,11 +11946,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -11959,11 +11969,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -11982,11 +11992,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -12005,11 +12015,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -12028,11 +12038,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -12051,11 +12061,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -12074,11 +12084,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -12097,11 +12107,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -12120,11 +12130,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -12143,11 +12153,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -12166,11 +12176,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -12189,11 +12199,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -12212,11 +12222,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -12235,11 +12245,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -12258,11 +12268,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -12281,11 +12291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -12304,11 +12314,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -12327,11 +12337,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -12350,11 +12360,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -12367,17 +12377,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -12396,11 +12406,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -12592,11 +12602,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -12715,7 +12725,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -12832,11 +12842,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -12854,11 +12864,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -13187,11 +13197,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -13211,6 +13221,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -13225,11 +13240,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -13263,11 +13278,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -13301,11 +13316,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -13339,11 +13354,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -13356,7 +13371,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -13368,11 +13383,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -13402,11 +13417,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -13430,11 +13445,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -13463,11 +13478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -13492,11 +13507,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -13521,11 +13536,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -13559,11 +13574,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -13597,11 +13612,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -13631,11 +13646,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -13660,11 +13675,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -13689,11 +13704,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -13718,11 +13733,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -13747,11 +13762,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -13759,7 +13774,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -13791,11 +13806,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -13829,11 +13844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -13857,11 +13872,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -13879,11 +13894,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -13898,11 +13913,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -13920,11 +13935,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -13953,11 +13968,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -13991,11 +14006,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -14003,12 +14018,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -14024,11 +14039,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -14036,7 +14051,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -14052,11 +14067,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -14085,11 +14100,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -14097,7 +14112,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -14119,11 +14134,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -14131,7 +14146,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -14157,11 +14172,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -14169,7 +14184,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -14192,11 +14207,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -14204,7 +14219,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -14221,11 +14236,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -14233,7 +14248,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -14266,11 +14281,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -14278,7 +14293,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -14295,11 +14310,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -14307,7 +14322,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -14330,11 +14345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -14363,11 +14378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -14396,11 +14411,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -14413,7 +14428,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -14434,11 +14449,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -14451,7 +14466,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -14467,11 +14482,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -14495,11 +14510,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -14523,11 +14538,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -14545,7 +14560,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -14561,11 +14576,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -14595,11 +14610,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -14623,11 +14638,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -14645,11 +14660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -14667,11 +14682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -14696,11 +14711,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -14724,11 +14739,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -14938,11 +14953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -14967,11 +14982,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -15044,11 +15059,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -15122,11 +15137,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -15200,11 +15215,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -15255,11 +15270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -15284,11 +15299,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -15306,11 +15321,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -15344,11 +15359,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -15361,7 +15376,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -15382,11 +15397,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -15399,7 +15414,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -15416,11 +15431,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -15444,11 +15459,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -15477,11 +15492,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -15505,11 +15520,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -15527,7 +15542,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -15543,11 +15558,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -15572,11 +15587,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -15605,16 +15620,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -15644,11 +15659,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -15698,11 +15713,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -15720,11 +15735,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -15742,11 +15757,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -15775,11 +15790,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -15809,11 +15824,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -15844,7 +15859,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridStringRenderer",
           "attributes": [
             {
@@ -15980,11 +15995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -16003,11 +16018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -16026,11 +16041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -16049,11 +16064,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -16072,11 +16087,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -16095,11 +16110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -16118,11 +16133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -16141,11 +16156,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -16164,11 +16179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -16187,11 +16202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -16210,11 +16225,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -16233,11 +16248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -16256,11 +16271,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -16279,11 +16294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -16302,11 +16317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -16325,11 +16340,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -16348,11 +16363,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -16371,11 +16386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -16394,11 +16409,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -16417,11 +16432,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -16440,11 +16455,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -16463,11 +16478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -16486,11 +16501,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -16503,17 +16518,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -16532,11 +16547,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -16867,11 +16882,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -16990,7 +17005,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -17107,11 +17122,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -17129,11 +17144,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -17462,11 +17477,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -17486,6 +17501,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -17500,11 +17520,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -17538,11 +17558,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -17576,11 +17596,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -17614,11 +17634,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -17631,7 +17651,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -17643,11 +17663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -17677,11 +17697,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -17705,11 +17725,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -17738,11 +17758,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -17767,11 +17787,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -17796,11 +17816,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -17834,11 +17854,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -17872,11 +17892,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -17906,11 +17926,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -17935,11 +17955,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -17964,11 +17984,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -17993,11 +18013,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -18022,11 +18042,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -18034,7 +18054,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -18066,11 +18086,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -18104,11 +18124,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -18132,11 +18152,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -18154,11 +18174,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -18173,11 +18193,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -18195,11 +18215,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -18228,11 +18248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -18266,11 +18286,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -18278,12 +18298,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -18299,11 +18319,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -18311,7 +18331,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -18327,11 +18347,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -18360,11 +18380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -18372,7 +18392,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -18394,11 +18414,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -18406,7 +18426,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -18432,11 +18452,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -18444,7 +18464,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -18467,11 +18487,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -18479,7 +18499,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -18496,11 +18516,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -18508,7 +18528,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -18541,11 +18561,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -18553,7 +18573,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -18570,11 +18590,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -18582,7 +18602,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -18605,11 +18625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -18638,11 +18658,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -18671,11 +18691,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -18688,7 +18708,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -18709,11 +18729,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -18726,7 +18746,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -18742,11 +18762,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -18770,11 +18790,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -18798,11 +18818,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -18820,7 +18840,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -18836,11 +18856,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -18870,11 +18890,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -18898,11 +18918,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -18920,11 +18940,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -18942,11 +18962,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -18971,11 +18991,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -18999,11 +19019,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -19318,11 +19338,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -19347,11 +19367,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -19424,11 +19444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -19502,11 +19522,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -19580,11 +19600,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -19635,11 +19655,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -19664,11 +19684,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -19686,11 +19706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -19724,11 +19744,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -19741,7 +19761,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -19762,11 +19782,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -19779,7 +19799,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -19796,11 +19816,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -19824,11 +19844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -19857,11 +19877,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -19885,11 +19905,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -19907,7 +19927,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -19923,11 +19943,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -19952,11 +19972,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -19985,16 +20005,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -20024,11 +20044,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -20078,11 +20098,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -20100,11 +20120,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -20122,11 +20142,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -20155,11 +20175,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -20189,11 +20209,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -20224,7 +20244,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridDateRenderer",
           "attributes": [
             {
@@ -20456,11 +20476,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -20479,11 +20499,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -20502,11 +20522,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -20525,11 +20545,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -20548,11 +20568,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -20571,11 +20591,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -20594,11 +20614,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -20617,11 +20637,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -20640,11 +20660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -20663,11 +20683,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -20686,11 +20706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -20709,11 +20729,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -20732,11 +20752,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -20755,11 +20775,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -20778,11 +20798,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -20801,11 +20821,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -20824,11 +20844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -20847,11 +20867,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -20870,11 +20890,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -20893,11 +20913,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -20916,11 +20936,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -20939,11 +20959,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -20962,11 +20982,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -20979,17 +20999,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -21008,11 +21028,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -21316,11 +21336,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -21439,7 +21459,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -21556,11 +21576,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -21578,11 +21598,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -21911,11 +21931,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -21935,6 +21955,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -21949,11 +21974,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -21987,11 +22012,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -22025,11 +22050,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -22063,11 +22088,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -22080,7 +22105,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -22092,11 +22117,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -22126,11 +22151,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -22154,11 +22179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -22187,11 +22212,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -22216,11 +22241,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -22245,11 +22270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -22283,11 +22308,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -22321,11 +22346,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -22355,11 +22380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -22384,11 +22409,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -22413,11 +22438,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -22442,11 +22467,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -22471,11 +22496,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -22483,7 +22508,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -22515,11 +22540,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -22553,11 +22578,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -22581,11 +22606,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -22603,11 +22628,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -22622,11 +22647,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -22644,11 +22669,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -22677,11 +22702,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -22715,11 +22740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -22727,12 +22752,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -22748,11 +22773,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -22760,7 +22785,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -22776,11 +22801,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -22809,11 +22834,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -22821,7 +22846,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -22843,11 +22868,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -22855,7 +22880,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -22881,11 +22906,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -22893,7 +22918,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -22916,11 +22941,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -22928,7 +22953,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -22945,11 +22970,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -22957,7 +22982,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -22990,11 +23015,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -23002,7 +23027,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -23019,11 +23044,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -23031,7 +23056,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -23054,11 +23079,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -23087,11 +23112,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -23120,11 +23145,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -23137,7 +23162,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -23158,11 +23183,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -23175,7 +23200,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -23191,11 +23216,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -23219,11 +23244,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -23247,11 +23272,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -23269,7 +23294,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -23285,11 +23310,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -23319,11 +23344,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -23347,11 +23372,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -23369,11 +23394,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -23391,11 +23416,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -23420,11 +23445,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -23448,11 +23473,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -23767,11 +23792,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -23796,11 +23821,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -23873,11 +23898,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -23951,11 +23976,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -24029,11 +24054,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -24084,11 +24109,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -24113,11 +24138,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -24135,11 +24160,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -24173,11 +24198,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -24190,7 +24215,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -24211,11 +24236,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -24228,7 +24253,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -24245,11 +24270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -24273,11 +24298,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -24306,11 +24331,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -24334,11 +24359,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -24356,7 +24381,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -24372,11 +24397,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -24401,11 +24426,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -24434,16 +24459,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -24473,11 +24498,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -24527,11 +24552,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -24549,11 +24574,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -24571,11 +24596,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -24604,11 +24629,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -24638,11 +24663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -24673,7 +24698,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridNumberRenderer",
           "attributes": [
             {
@@ -24869,11 +24894,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -24892,11 +24917,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -24915,11 +24940,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -24938,11 +24963,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -24961,11 +24986,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -24984,11 +25009,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -25007,11 +25032,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -25030,11 +25055,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -25053,11 +25078,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -25076,11 +25101,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -25099,11 +25124,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -25122,11 +25147,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -25145,11 +25170,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -25168,11 +25193,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -25191,11 +25216,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -25214,11 +25239,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -25237,11 +25262,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -25260,11 +25285,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -25283,11 +25308,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -25306,11 +25331,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -25329,11 +25354,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -25352,11 +25377,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -25375,11 +25400,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -25392,17 +25417,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -25421,11 +25446,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -25563,11 +25588,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -25686,7 +25711,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -25820,11 +25845,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -26153,11 +26178,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -26177,6 +26202,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -26191,11 +26221,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -26229,11 +26259,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -26267,11 +26297,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -26305,11 +26335,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -26322,7 +26352,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -26334,11 +26364,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -26368,11 +26398,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -26396,11 +26426,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -26429,11 +26459,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -26458,11 +26488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -26487,11 +26517,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -26525,11 +26555,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -26563,11 +26593,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -26597,11 +26627,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -26626,11 +26656,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -26655,11 +26685,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -26684,11 +26714,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -26713,11 +26743,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -26725,7 +26755,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -26757,11 +26787,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -26795,11 +26825,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -26823,11 +26853,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -26845,11 +26875,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -26864,11 +26894,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -26886,11 +26916,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -26919,11 +26949,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -26957,11 +26987,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -26969,12 +26999,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -26990,11 +27020,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -27002,7 +27032,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -27018,11 +27048,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -27051,11 +27081,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -27063,7 +27093,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -27085,11 +27115,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -27097,7 +27127,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -27123,11 +27153,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -27135,7 +27165,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -27158,11 +27188,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -27170,7 +27200,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -27187,11 +27217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -27199,7 +27229,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -27232,11 +27262,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -27244,7 +27274,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -27261,11 +27291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -27273,7 +27303,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -27296,11 +27326,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -27329,11 +27359,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -27362,11 +27392,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -27379,7 +27409,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -27400,11 +27430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -27417,7 +27447,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -27433,11 +27463,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -27461,11 +27491,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -27489,11 +27519,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -27511,7 +27541,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -27527,11 +27557,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -27561,11 +27591,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -27589,11 +27619,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -27611,11 +27641,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -27633,11 +27663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -27662,11 +27692,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -27690,11 +27720,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -27894,11 +27924,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -27923,11 +27953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -28000,11 +28030,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -28078,11 +28108,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -28156,11 +28186,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -28211,11 +28241,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -28240,11 +28270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -28262,11 +28292,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -28300,11 +28330,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -28317,7 +28347,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -28338,11 +28368,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -28355,7 +28385,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -28372,11 +28402,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -28400,11 +28430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -28433,11 +28463,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -28461,11 +28491,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -28483,7 +28513,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -28499,11 +28529,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -28528,11 +28558,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -28561,16 +28591,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -28600,11 +28630,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -28654,11 +28684,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -28676,11 +28706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -28698,11 +28728,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -28731,11 +28761,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -28765,11 +28795,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -28800,7 +28830,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridCellContentWrapperElement",
           "attributes": [
             {
@@ -28896,11 +28926,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -28919,11 +28949,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -28942,11 +28972,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -28965,11 +28995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -28988,11 +29018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -29011,11 +29041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -29034,11 +29064,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -29057,11 +29087,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -29080,11 +29110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -29103,11 +29133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -29126,11 +29156,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -29149,11 +29179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -29172,11 +29202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -29195,11 +29225,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -29218,11 +29248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -29241,11 +29271,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -29264,11 +29294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -29287,11 +29317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -29310,11 +29340,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -29333,11 +29363,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -29356,11 +29386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -29379,11 +29409,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -29402,11 +29432,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -29419,17 +29449,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -29448,11 +29478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -29895,11 +29925,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -30018,7 +30048,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -30135,11 +30165,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -30157,11 +30187,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -30490,11 +30520,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -30514,6 +30544,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -30528,11 +30563,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -30566,11 +30601,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -30604,11 +30639,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -30642,11 +30677,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -30659,7 +30694,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -30671,11 +30706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -30705,11 +30740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -30733,11 +30768,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -30766,11 +30801,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -30795,11 +30830,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -30824,11 +30859,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -30862,11 +30897,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -30900,11 +30935,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -30934,11 +30969,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -30963,11 +30998,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -30992,11 +31027,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -31021,11 +31056,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -31050,11 +31085,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -31062,7 +31097,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -31094,11 +31129,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -31132,11 +31167,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -31160,11 +31195,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -31182,11 +31217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -31201,11 +31236,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -31223,11 +31258,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -31256,11 +31291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -31294,11 +31329,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -31306,12 +31341,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -31327,11 +31362,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -31339,7 +31374,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -31355,11 +31390,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -31388,11 +31423,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -31400,7 +31435,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -31422,11 +31457,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -31434,7 +31469,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -31460,11 +31495,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -31472,7 +31507,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -31495,11 +31530,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -31507,7 +31542,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -31524,11 +31559,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -31536,7 +31571,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -31569,11 +31604,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -31581,7 +31616,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -31598,11 +31633,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -31610,7 +31645,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -31633,11 +31668,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -31666,11 +31701,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -31699,11 +31734,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -31716,7 +31751,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -31737,11 +31772,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -31754,7 +31789,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -31770,11 +31805,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -31798,11 +31833,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -31826,11 +31861,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -31848,7 +31883,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -31864,11 +31899,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -31898,11 +31933,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -31926,11 +31961,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -31948,11 +31983,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -31970,11 +32005,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -31999,11 +32034,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -32027,11 +32062,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -32547,11 +32582,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -32576,11 +32611,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -32653,11 +32688,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -32731,11 +32766,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -32809,11 +32844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -32864,11 +32899,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -32893,11 +32928,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -32915,11 +32950,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -32953,11 +32988,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -32970,7 +33005,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -32991,11 +33026,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -33008,7 +33043,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -33025,11 +33060,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -33053,11 +33088,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -33086,11 +33121,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -33114,11 +33149,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -33136,7 +33171,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -33152,11 +33187,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -33181,11 +33216,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -33214,16 +33249,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -33253,11 +33288,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -33307,11 +33342,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -33329,11 +33364,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -33351,11 +33386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -33384,11 +33419,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -33418,11 +33453,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -33453,7 +33488,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFilterEntityElement",
           "attributes": [
             {
@@ -33590,11 +33625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -33613,11 +33648,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -33636,11 +33671,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -33659,11 +33694,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -33682,11 +33717,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -33705,11 +33740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -33728,11 +33763,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -33751,11 +33786,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -33774,11 +33809,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -33797,11 +33832,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -33820,11 +33855,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -33843,11 +33878,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -33866,11 +33901,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -33889,11 +33924,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -33912,11 +33947,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -33935,11 +33970,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -33958,11 +33993,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -33981,11 +34016,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -34004,11 +34039,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -34027,11 +34062,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -34050,11 +34085,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -34073,11 +34108,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -34096,11 +34131,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -34113,17 +34148,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -34142,11 +34177,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -34341,11 +34376,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -34464,7 +34499,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -34598,11 +34633,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -34931,11 +34966,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -34955,6 +34990,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -34969,11 +35009,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -35007,11 +35047,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -35045,11 +35085,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -35083,11 +35123,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -35100,7 +35140,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -35112,11 +35152,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -35146,11 +35186,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -35174,11 +35214,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -35207,11 +35247,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -35236,11 +35276,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -35265,11 +35305,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -35303,11 +35343,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -35341,11 +35381,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -35375,11 +35415,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -35404,11 +35444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -35433,11 +35473,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -35462,11 +35502,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -35491,11 +35531,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -35503,7 +35543,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -35535,11 +35575,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -35573,11 +35613,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -35601,11 +35641,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -35623,11 +35663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -35642,11 +35682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -35664,11 +35704,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -35697,11 +35737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -35735,11 +35775,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -35747,12 +35787,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -35768,11 +35808,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -35780,7 +35820,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -35796,11 +35836,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -35829,11 +35869,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -35841,7 +35881,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -35863,11 +35903,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -35875,7 +35915,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -35901,11 +35941,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -35913,7 +35953,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -35936,11 +35976,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -35948,7 +35988,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -35965,11 +36005,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -35977,7 +36017,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -36010,11 +36050,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -36022,7 +36062,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -36039,11 +36079,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -36051,7 +36091,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -36074,11 +36114,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -36107,11 +36147,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -36140,11 +36180,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -36157,7 +36197,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -36178,11 +36218,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -36195,7 +36235,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -36211,11 +36251,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -36239,11 +36279,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -36267,11 +36307,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -36289,7 +36329,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -36305,11 +36345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -36339,11 +36379,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -36367,11 +36407,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -36389,11 +36429,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -36411,11 +36451,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -36440,11 +36480,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -36468,11 +36508,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -36684,11 +36724,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -36713,11 +36753,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -36790,11 +36830,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -36868,11 +36908,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -36946,11 +36986,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -37001,11 +37041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -37030,11 +37070,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -37052,11 +37092,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -37090,11 +37130,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -37107,7 +37147,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -37128,11 +37168,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -37145,7 +37185,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -37162,11 +37202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -37190,11 +37230,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -37223,11 +37263,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -37251,11 +37291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -37273,7 +37313,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -37289,11 +37329,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -37318,11 +37358,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -37351,16 +37391,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -37390,11 +37430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -37444,11 +37484,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -37466,11 +37506,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -37488,11 +37528,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -37521,11 +37561,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -37555,11 +37595,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -37590,7 +37630,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFilterSectionElement",
           "attributes": [
             {
@@ -37711,11 +37751,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -37734,11 +37774,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -37757,11 +37797,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -37780,11 +37820,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -37803,11 +37843,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -37826,11 +37866,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -37849,11 +37889,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -37872,11 +37912,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -37895,11 +37935,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -37918,11 +37958,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -37941,11 +37981,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -37964,11 +38004,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -37987,11 +38027,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -38010,11 +38050,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -38033,11 +38073,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -38056,11 +38096,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -38079,11 +38119,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -38102,11 +38142,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -38125,11 +38165,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -38148,11 +38188,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -38171,11 +38211,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -38194,11 +38234,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -38217,11 +38257,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -38234,17 +38274,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -38263,11 +38303,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -38425,11 +38465,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -38548,7 +38588,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -38665,11 +38705,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -38687,11 +38727,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -39020,11 +39060,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -39044,6 +39084,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -39058,11 +39103,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -39096,11 +39141,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -39134,11 +39179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -39172,11 +39217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -39189,7 +39234,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -39201,11 +39246,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -39235,11 +39280,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -39263,11 +39308,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -39296,11 +39341,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -39325,11 +39370,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -39354,11 +39399,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -39392,11 +39437,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -39430,11 +39475,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -39464,11 +39509,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -39493,11 +39538,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -39522,11 +39567,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -39551,11 +39596,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -39580,11 +39625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -39592,7 +39637,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -39624,11 +39669,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -39662,11 +39707,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -39690,11 +39735,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -39712,11 +39757,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -39731,11 +39776,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -39753,11 +39798,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -39786,11 +39831,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -39824,11 +39869,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -39836,12 +39881,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -39857,11 +39902,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -39869,7 +39914,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -39885,11 +39930,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -39918,11 +39963,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -39930,7 +39975,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -39952,11 +39997,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -39964,7 +40009,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -39990,11 +40035,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -40002,7 +40047,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -40025,11 +40070,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -40037,7 +40082,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -40054,11 +40099,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -40066,7 +40111,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -40099,11 +40144,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -40111,7 +40156,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -40128,11 +40173,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -40140,7 +40185,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -40163,11 +40208,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -40196,11 +40241,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -40229,11 +40274,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -40246,7 +40291,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -40267,11 +40312,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -40284,7 +40329,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -40300,11 +40345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -40328,11 +40373,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -40356,11 +40401,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -40378,7 +40423,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -40394,11 +40439,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -40428,11 +40473,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -40456,11 +40501,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -40478,11 +40523,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -40500,11 +40545,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -40529,11 +40574,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -40557,11 +40602,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -40733,11 +40778,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -40762,11 +40807,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -40839,11 +40884,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -40917,11 +40962,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -40995,11 +41040,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -41050,11 +41095,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -41079,11 +41124,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -41101,11 +41146,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -41139,11 +41184,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -41156,7 +41201,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -41177,11 +41222,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -41194,7 +41239,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -41211,11 +41256,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -41239,11 +41284,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -41272,11 +41317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -41300,11 +41345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -41322,7 +41367,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -41338,11 +41383,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -41367,11 +41412,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -41400,16 +41445,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -41439,11 +41484,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -41493,11 +41538,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -41515,11 +41560,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -41537,11 +41582,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -41570,11 +41615,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -41604,11 +41649,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -41639,7 +41684,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFilterElement",
           "attributes": [
             {
@@ -41789,11 +41834,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -41812,11 +41857,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -41835,11 +41880,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -41858,11 +41903,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -41881,11 +41926,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -41904,11 +41949,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -41927,11 +41972,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -41950,11 +41995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -41973,11 +42018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -41996,11 +42041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -42019,11 +42064,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -42042,11 +42087,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -42065,11 +42110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -42088,11 +42133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -42111,11 +42156,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -42134,11 +42179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -42157,11 +42202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -42180,11 +42225,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -42203,11 +42248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -42226,11 +42271,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -42249,11 +42294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -42272,11 +42317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -42295,11 +42340,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -42312,17 +42357,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -42341,11 +42386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -42540,11 +42585,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -42663,7 +42708,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -42797,11 +42842,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -43130,11 +43175,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -43154,6 +43199,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -43168,11 +43218,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -43206,11 +43256,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -43244,11 +43294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -43282,11 +43332,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -43299,7 +43349,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -43311,11 +43361,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -43345,11 +43395,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -43373,11 +43423,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -43406,11 +43456,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -43435,11 +43485,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -43464,11 +43514,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -43502,11 +43552,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -43540,11 +43590,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -43574,11 +43624,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -43603,11 +43653,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -43632,11 +43682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -43661,11 +43711,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -43690,11 +43740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -43702,7 +43752,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -43734,11 +43784,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -43772,11 +43822,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -43800,11 +43850,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -43822,11 +43872,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -43841,11 +43891,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -43863,11 +43913,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -43896,11 +43946,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -43934,11 +43984,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -43946,12 +43996,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -43967,11 +44017,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -43979,7 +44029,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -43995,11 +44045,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -44028,11 +44078,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -44040,7 +44090,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -44062,11 +44112,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -44074,7 +44124,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -44100,11 +44150,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -44112,7 +44162,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -44135,11 +44185,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -44147,7 +44197,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -44164,11 +44214,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -44176,7 +44226,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -44209,11 +44259,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -44221,7 +44271,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -44238,11 +44288,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -44250,7 +44300,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -44273,11 +44323,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -44306,11 +44356,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -44339,11 +44389,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -44356,7 +44406,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -44377,11 +44427,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -44394,7 +44444,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -44410,11 +44460,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -44438,11 +44488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -44466,11 +44516,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -44488,7 +44538,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -44504,11 +44554,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -44538,11 +44588,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -44566,11 +44616,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -44588,11 +44638,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -44610,11 +44660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -44639,11 +44689,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -44667,11 +44717,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -44850,11 +44900,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -44879,11 +44929,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -44956,11 +45006,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -45034,11 +45084,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -45112,11 +45162,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -45167,11 +45217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -45196,11 +45246,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -45218,11 +45268,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -45256,11 +45306,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -45273,7 +45323,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -45294,11 +45344,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -45311,7 +45361,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -45328,11 +45378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -45356,11 +45406,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -45389,11 +45439,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -45417,11 +45467,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -45439,7 +45489,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -45455,11 +45505,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -45484,11 +45534,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -45517,16 +45567,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -45556,11 +45606,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -45610,11 +45660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -45632,11 +45682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -45654,11 +45704,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -45687,11 +45737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -45721,11 +45771,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -45756,7 +45806,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFiltersModalElement",
           "attributes": [
             {
@@ -45916,11 +45966,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -45939,11 +45989,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -45962,11 +46012,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -45985,11 +46035,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -46008,11 +46058,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -46031,11 +46081,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -46054,11 +46104,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -46077,11 +46127,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -46100,11 +46150,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -46123,11 +46173,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -46146,11 +46196,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -46169,11 +46219,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -46192,11 +46242,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -46215,11 +46265,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -46238,11 +46288,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -46261,11 +46311,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -46284,11 +46334,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -46307,11 +46357,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -46330,11 +46380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -46353,11 +46403,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -46376,11 +46426,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -46399,11 +46449,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -46422,11 +46472,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -46439,17 +46489,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -46468,11 +46518,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -46590,11 +46640,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -46713,7 +46763,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -46847,11 +46897,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -47180,11 +47230,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -47204,6 +47254,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -47218,11 +47273,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -47256,11 +47311,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -47294,11 +47349,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -47332,11 +47387,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -47349,7 +47404,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -47361,11 +47416,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -47395,11 +47450,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -47423,11 +47478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -47456,11 +47511,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -47485,11 +47540,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -47514,11 +47569,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -47552,11 +47607,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -47590,11 +47645,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -47624,11 +47679,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -47653,11 +47708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -47682,11 +47737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -47711,11 +47766,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -47740,11 +47795,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -47752,7 +47807,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -47784,11 +47839,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -47822,11 +47877,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -47850,11 +47905,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -47872,11 +47927,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -47891,11 +47946,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -47913,11 +47968,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -47946,11 +48001,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -47984,11 +48039,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -47996,12 +48051,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -48017,11 +48072,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -48029,7 +48084,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -48045,11 +48100,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -48078,11 +48133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -48090,7 +48145,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -48112,11 +48167,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -48124,7 +48179,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -48150,11 +48205,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -48162,7 +48217,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -48185,11 +48240,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -48197,7 +48252,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -48214,11 +48269,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -48226,7 +48281,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -48259,11 +48314,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -48271,7 +48326,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -48288,11 +48343,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -48300,7 +48355,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -48323,11 +48378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -48356,11 +48411,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -48389,11 +48444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -48406,7 +48461,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -48427,11 +48482,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -48444,7 +48499,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -48460,11 +48515,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -48488,11 +48543,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -48516,11 +48571,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -48538,7 +48593,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -48554,11 +48609,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -48588,11 +48643,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -48616,11 +48671,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -48638,11 +48693,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -48660,11 +48715,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -48689,11 +48744,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -48717,11 +48772,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -49164,11 +49219,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -49193,11 +49248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -49270,11 +49325,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -49348,11 +49403,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -49426,11 +49481,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -49481,11 +49536,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -49510,11 +49565,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -49532,11 +49587,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -49570,11 +49625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -49587,7 +49642,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -49608,11 +49663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -49625,7 +49680,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -49642,11 +49697,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -49670,11 +49725,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -49703,11 +49758,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -49731,11 +49786,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -49753,7 +49808,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -49769,11 +49824,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -49798,11 +49853,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -49831,16 +49886,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -49870,11 +49925,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -49924,11 +49979,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -49946,11 +50001,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -49968,11 +50023,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -50001,11 +50056,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -50035,11 +50090,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -50070,7 +50125,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFiltersPreviewElement",
           "attributes": [
             {
@@ -52672,7 +52727,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridEditColumnElement",
           "attributes": [
             {

--- a/px-data-grid-paginated-api.json
+++ b/px-data-grid-paginated-api.json
@@ -1274,7 +1274,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridColumnElement",
           "attributes": [
             {
@@ -1501,11 +1501,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -1524,11 +1524,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -1547,11 +1547,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -1570,11 +1570,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -1593,11 +1593,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -1616,11 +1616,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -1639,11 +1639,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -1662,11 +1662,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -1685,11 +1685,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -1708,11 +1708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -1731,11 +1731,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -1754,11 +1754,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -1777,11 +1777,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -1800,11 +1800,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -1823,11 +1823,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -1846,11 +1846,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -1869,11 +1869,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -1892,11 +1892,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -1915,11 +1915,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -1938,11 +1938,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -1961,11 +1961,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -1984,11 +1984,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -2007,11 +2007,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -2024,17 +2024,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -2053,11 +2053,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -2138,11 +2138,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -2261,7 +2261,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -2378,11 +2378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -2400,11 +2400,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -2733,11 +2733,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -2757,6 +2757,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -2771,11 +2776,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -2809,11 +2814,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -2847,11 +2852,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -2885,11 +2890,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -2902,7 +2907,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -2914,11 +2919,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -2948,11 +2953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -2976,11 +2981,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -3009,11 +3014,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -3038,11 +3043,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -3067,11 +3072,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -3105,11 +3110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -3143,11 +3148,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -3177,11 +3182,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -3206,11 +3211,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -3235,11 +3240,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -3264,11 +3269,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -3293,11 +3298,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -3305,7 +3310,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -3337,11 +3342,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -3375,11 +3380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -3403,11 +3408,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -3425,11 +3430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -3444,11 +3449,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -3466,11 +3471,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -3499,11 +3504,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -3537,11 +3542,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -3549,12 +3554,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -3570,11 +3575,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -3582,7 +3587,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -3598,11 +3603,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -3631,11 +3636,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -3643,7 +3648,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -3665,11 +3670,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -3677,7 +3682,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -3703,11 +3708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -3715,7 +3720,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -3738,11 +3743,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -3750,7 +3755,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -3767,11 +3772,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -3779,7 +3784,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -3812,11 +3817,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -3824,7 +3829,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -3841,11 +3846,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -3853,7 +3858,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -3876,11 +3881,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -3909,11 +3914,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -3942,11 +3947,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -3959,7 +3964,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -3980,11 +3985,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -3997,7 +4002,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -4013,11 +4018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -4041,11 +4046,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -4069,11 +4074,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -4091,7 +4096,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -4107,11 +4112,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -4141,11 +4146,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -4169,11 +4174,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -4191,11 +4196,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -4213,11 +4218,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -4242,11 +4247,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -4270,11 +4275,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -4357,11 +4362,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -4386,11 +4391,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -4463,11 +4468,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -4541,11 +4546,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -4619,11 +4624,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -4674,11 +4679,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -4703,11 +4708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -4725,11 +4730,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -4763,11 +4768,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -4780,7 +4785,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -4801,11 +4806,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -4818,7 +4823,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -4835,11 +4840,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -4863,11 +4868,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -4896,11 +4901,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -4924,11 +4929,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -4946,7 +4951,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -4962,11 +4967,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -4991,11 +4996,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -5024,16 +5029,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -5063,11 +5068,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -5117,11 +5122,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -5139,11 +5144,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -5161,11 +5166,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -5194,11 +5199,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -5228,11 +5233,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -5263,7 +5268,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.AutoFilterFieldElement",
           "attributes": [
             {
@@ -5343,11 +5348,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -5366,11 +5371,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -5389,11 +5394,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -5412,11 +5417,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -5435,11 +5440,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -5458,11 +5463,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -5481,11 +5486,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -5504,11 +5509,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -5527,11 +5532,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -5550,11 +5555,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -5573,11 +5578,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -5596,11 +5601,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -5619,11 +5624,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -5642,11 +5647,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -5665,11 +5670,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -5688,11 +5693,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -5711,11 +5716,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -5734,11 +5739,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -5757,11 +5762,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -5780,11 +5785,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -5803,11 +5808,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -5826,11 +5831,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -5849,11 +5854,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -5866,17 +5871,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -5895,11 +5900,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -6018,11 +6023,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -6141,7 +6146,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -6258,11 +6263,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -6280,11 +6285,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -6613,11 +6618,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -6637,6 +6642,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -6651,11 +6661,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -6689,11 +6699,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -6727,11 +6737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -6765,11 +6775,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -6782,7 +6792,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -6794,11 +6804,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -6828,11 +6838,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -6856,11 +6866,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -6889,11 +6899,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -6918,11 +6928,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -6947,11 +6957,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -6985,11 +6995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -7023,11 +7033,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -7057,11 +7067,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -7086,11 +7096,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -7115,11 +7125,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -7144,11 +7154,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -7173,11 +7183,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -7185,7 +7195,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -7217,11 +7227,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -7255,11 +7265,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -7283,11 +7293,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -7305,11 +7315,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -7324,11 +7334,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -7346,11 +7356,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -7379,11 +7389,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -7417,11 +7427,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -7429,12 +7439,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -7450,11 +7460,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -7462,7 +7472,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -7478,11 +7488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -7511,11 +7521,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -7523,7 +7533,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -7545,11 +7555,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -7557,7 +7567,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -7583,11 +7593,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -7595,7 +7605,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -7618,11 +7628,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -7630,7 +7640,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -7647,11 +7657,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -7659,7 +7669,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -7692,11 +7702,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -7704,7 +7714,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -7721,11 +7731,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -7733,7 +7743,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -7756,11 +7766,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -7789,11 +7799,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -7822,11 +7832,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -7839,7 +7849,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -7860,11 +7870,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -7877,7 +7887,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -7893,11 +7903,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -7921,11 +7931,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -7949,11 +7959,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -7971,7 +7981,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -7987,11 +7997,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -8021,11 +8031,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -8049,11 +8059,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -8071,11 +8081,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -8093,11 +8103,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -8122,11 +8132,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -8150,11 +8160,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -8241,11 +8251,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -8270,11 +8280,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -8347,11 +8357,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -8425,11 +8435,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -8503,11 +8513,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -8558,11 +8568,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -8587,11 +8597,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -8609,11 +8619,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -8647,11 +8657,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -8664,7 +8674,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -8685,11 +8695,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -8702,7 +8712,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -8719,11 +8729,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -8747,11 +8757,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -8780,11 +8790,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -8808,11 +8818,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -8830,7 +8840,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -8846,11 +8856,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -8875,11 +8885,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -8908,16 +8918,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -8947,11 +8957,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -9001,11 +9011,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -9023,11 +9033,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -9045,11 +9055,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -9078,11 +9088,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -9112,11 +9122,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -9147,7 +9157,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridSelectAllElement",
           "attributes": [
             {
@@ -10539,7 +10549,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridSelectionColumnElement",
           "attributes": [
             {
@@ -11714,7 +11724,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridToggleDetailsColumnElement",
           "attributes": [
             {
@@ -11844,11 +11854,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -11867,11 +11877,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -11890,11 +11900,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -11913,11 +11923,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -11936,11 +11946,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -11959,11 +11969,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -11982,11 +11992,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -12005,11 +12015,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -12028,11 +12038,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -12051,11 +12061,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -12074,11 +12084,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -12097,11 +12107,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -12120,11 +12130,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -12143,11 +12153,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -12166,11 +12176,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -12189,11 +12199,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -12212,11 +12222,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -12235,11 +12245,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -12258,11 +12268,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -12281,11 +12291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -12304,11 +12314,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -12327,11 +12337,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -12350,11 +12360,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -12367,17 +12377,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -12396,11 +12406,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -12592,11 +12602,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -12715,7 +12725,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -12832,11 +12842,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -12854,11 +12864,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -13187,11 +13197,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -13211,6 +13221,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -13225,11 +13240,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -13263,11 +13278,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -13301,11 +13316,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -13339,11 +13354,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -13356,7 +13371,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -13368,11 +13383,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -13402,11 +13417,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -13430,11 +13445,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -13463,11 +13478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -13492,11 +13507,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -13521,11 +13536,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -13559,11 +13574,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -13597,11 +13612,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -13631,11 +13646,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -13660,11 +13675,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -13689,11 +13704,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -13718,11 +13733,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -13747,11 +13762,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -13759,7 +13774,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -13791,11 +13806,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -13829,11 +13844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -13857,11 +13872,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -13879,11 +13894,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -13898,11 +13913,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -13920,11 +13935,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -13953,11 +13968,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -13991,11 +14006,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -14003,12 +14018,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -14024,11 +14039,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -14036,7 +14051,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -14052,11 +14067,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -14085,11 +14100,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -14097,7 +14112,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -14119,11 +14134,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -14131,7 +14146,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -14157,11 +14172,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -14169,7 +14184,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -14192,11 +14207,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -14204,7 +14219,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -14221,11 +14236,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -14233,7 +14248,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -14266,11 +14281,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -14278,7 +14293,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -14295,11 +14310,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -14307,7 +14322,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -14330,11 +14345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -14363,11 +14378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -14396,11 +14411,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -14413,7 +14428,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -14434,11 +14449,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -14451,7 +14466,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -14467,11 +14482,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -14495,11 +14510,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -14523,11 +14538,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -14545,7 +14560,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -14561,11 +14576,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -14595,11 +14610,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -14623,11 +14638,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -14645,11 +14660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -14667,11 +14682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -14696,11 +14711,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -14724,11 +14739,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -14938,11 +14953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -14967,11 +14982,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -15044,11 +15059,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -15122,11 +15137,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -15200,11 +15215,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -15255,11 +15270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -15284,11 +15299,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -15306,11 +15321,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -15344,11 +15359,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -15361,7 +15376,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -15382,11 +15397,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -15399,7 +15414,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -15416,11 +15431,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -15444,11 +15459,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -15477,11 +15492,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -15505,11 +15520,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -15527,7 +15542,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -15543,11 +15558,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -15572,11 +15587,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -15605,16 +15620,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -15644,11 +15659,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -15698,11 +15713,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -15720,11 +15735,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -15742,11 +15757,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -15775,11 +15790,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -15809,11 +15824,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -15844,7 +15859,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridStringRenderer",
           "attributes": [
             {
@@ -15980,11 +15995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -16003,11 +16018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -16026,11 +16041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -16049,11 +16064,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -16072,11 +16087,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -16095,11 +16110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -16118,11 +16133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -16141,11 +16156,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -16164,11 +16179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -16187,11 +16202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -16210,11 +16225,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -16233,11 +16248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -16256,11 +16271,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -16279,11 +16294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -16302,11 +16317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -16325,11 +16340,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -16348,11 +16363,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -16371,11 +16386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -16394,11 +16409,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -16417,11 +16432,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -16440,11 +16455,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -16463,11 +16478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -16486,11 +16501,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -16503,17 +16518,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -16532,11 +16547,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -16867,11 +16882,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -16990,7 +17005,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -17107,11 +17122,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -17129,11 +17144,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -17462,11 +17477,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -17486,6 +17501,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -17500,11 +17520,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -17538,11 +17558,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -17576,11 +17596,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -17614,11 +17634,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -17631,7 +17651,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -17643,11 +17663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -17677,11 +17697,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -17705,11 +17725,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -17738,11 +17758,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -17767,11 +17787,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -17796,11 +17816,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -17834,11 +17854,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -17872,11 +17892,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -17906,11 +17926,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -17935,11 +17955,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -17964,11 +17984,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -17993,11 +18013,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -18022,11 +18042,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -18034,7 +18054,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -18066,11 +18086,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -18104,11 +18124,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -18132,11 +18152,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -18154,11 +18174,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -18173,11 +18193,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -18195,11 +18215,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -18228,11 +18248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -18266,11 +18286,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -18278,12 +18298,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -18299,11 +18319,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -18311,7 +18331,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -18327,11 +18347,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -18360,11 +18380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -18372,7 +18392,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -18394,11 +18414,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -18406,7 +18426,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -18432,11 +18452,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -18444,7 +18464,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -18467,11 +18487,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -18479,7 +18499,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -18496,11 +18516,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -18508,7 +18528,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -18541,11 +18561,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -18553,7 +18573,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -18570,11 +18590,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -18582,7 +18602,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -18605,11 +18625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -18638,11 +18658,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -18671,11 +18691,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -18688,7 +18708,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -18709,11 +18729,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -18726,7 +18746,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -18742,11 +18762,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -18770,11 +18790,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -18798,11 +18818,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -18820,7 +18840,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -18836,11 +18856,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -18870,11 +18890,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -18898,11 +18918,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -18920,11 +18940,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -18942,11 +18962,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -18971,11 +18991,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -18999,11 +19019,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -19318,11 +19338,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -19347,11 +19367,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -19424,11 +19444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -19502,11 +19522,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -19580,11 +19600,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -19635,11 +19655,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -19664,11 +19684,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -19686,11 +19706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -19724,11 +19744,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -19741,7 +19761,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -19762,11 +19782,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -19779,7 +19799,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -19796,11 +19816,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -19824,11 +19844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -19857,11 +19877,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -19885,11 +19905,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -19907,7 +19927,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -19923,11 +19943,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -19952,11 +19972,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -19985,16 +20005,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -20024,11 +20044,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -20078,11 +20098,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -20100,11 +20120,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -20122,11 +20142,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -20155,11 +20175,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -20189,11 +20209,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -20224,7 +20244,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridDateRenderer",
           "attributes": [
             {
@@ -20456,11 +20476,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -20479,11 +20499,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -20502,11 +20522,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -20525,11 +20545,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -20548,11 +20568,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -20571,11 +20591,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -20594,11 +20614,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -20617,11 +20637,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -20640,11 +20660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -20663,11 +20683,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -20686,11 +20706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -20709,11 +20729,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -20732,11 +20752,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -20755,11 +20775,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -20778,11 +20798,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -20801,11 +20821,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -20824,11 +20844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -20847,11 +20867,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -20870,11 +20890,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -20893,11 +20913,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -20916,11 +20936,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -20939,11 +20959,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -20962,11 +20982,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -20979,17 +20999,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -21008,11 +21028,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -21316,11 +21336,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -21439,7 +21459,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -21556,11 +21576,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -21578,11 +21598,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -21911,11 +21931,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -21935,6 +21955,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -21949,11 +21974,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -21987,11 +22012,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -22025,11 +22050,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -22063,11 +22088,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -22080,7 +22105,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -22092,11 +22117,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -22126,11 +22151,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -22154,11 +22179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -22187,11 +22212,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -22216,11 +22241,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -22245,11 +22270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -22283,11 +22308,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -22321,11 +22346,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -22355,11 +22380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -22384,11 +22409,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -22413,11 +22438,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -22442,11 +22467,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -22471,11 +22496,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -22483,7 +22508,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -22515,11 +22540,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -22553,11 +22578,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -22581,11 +22606,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -22603,11 +22628,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -22622,11 +22647,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -22644,11 +22669,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -22677,11 +22702,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -22715,11 +22740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -22727,12 +22752,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -22748,11 +22773,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -22760,7 +22785,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -22776,11 +22801,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -22809,11 +22834,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -22821,7 +22846,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -22843,11 +22868,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -22855,7 +22880,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -22881,11 +22906,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -22893,7 +22918,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -22916,11 +22941,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -22928,7 +22953,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -22945,11 +22970,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -22957,7 +22982,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -22990,11 +23015,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -23002,7 +23027,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -23019,11 +23044,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -23031,7 +23056,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -23054,11 +23079,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -23087,11 +23112,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -23120,11 +23145,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -23137,7 +23162,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -23158,11 +23183,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -23175,7 +23200,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -23191,11 +23216,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -23219,11 +23244,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -23247,11 +23272,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -23269,7 +23294,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -23285,11 +23310,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -23319,11 +23344,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -23347,11 +23372,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -23369,11 +23394,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -23391,11 +23416,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -23420,11 +23445,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -23448,11 +23473,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -23767,11 +23792,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -23796,11 +23821,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -23873,11 +23898,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -23951,11 +23976,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -24029,11 +24054,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -24084,11 +24109,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -24113,11 +24138,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -24135,11 +24160,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -24173,11 +24198,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -24190,7 +24215,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -24211,11 +24236,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -24228,7 +24253,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -24245,11 +24270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -24273,11 +24298,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -24306,11 +24331,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -24334,11 +24359,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -24356,7 +24381,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -24372,11 +24397,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -24401,11 +24426,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -24434,16 +24459,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -24473,11 +24498,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -24527,11 +24552,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -24549,11 +24574,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -24571,11 +24596,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -24604,11 +24629,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -24638,11 +24663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -24673,7 +24698,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridNumberRenderer",
           "attributes": [
             {
@@ -24869,11 +24894,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -24892,11 +24917,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -24915,11 +24940,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -24938,11 +24963,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -24961,11 +24986,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -24984,11 +25009,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -25007,11 +25032,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -25030,11 +25055,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -25053,11 +25078,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -25076,11 +25101,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -25099,11 +25124,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -25122,11 +25147,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -25145,11 +25170,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -25168,11 +25193,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -25191,11 +25216,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -25214,11 +25239,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -25237,11 +25262,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -25260,11 +25285,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -25283,11 +25308,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -25306,11 +25331,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -25329,11 +25354,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -25352,11 +25377,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -25375,11 +25400,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -25392,17 +25417,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -25421,11 +25446,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -25563,11 +25588,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -25686,7 +25711,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -25820,11 +25845,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -26153,11 +26178,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -26177,6 +26202,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -26191,11 +26221,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -26229,11 +26259,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -26267,11 +26297,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -26305,11 +26335,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -26322,7 +26352,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -26334,11 +26364,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -26368,11 +26398,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -26396,11 +26426,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -26429,11 +26459,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -26458,11 +26488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -26487,11 +26517,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -26525,11 +26555,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -26563,11 +26593,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -26597,11 +26627,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -26626,11 +26656,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -26655,11 +26685,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -26684,11 +26714,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -26713,11 +26743,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -26725,7 +26755,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -26757,11 +26787,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -26795,11 +26825,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -26823,11 +26853,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -26845,11 +26875,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -26864,11 +26894,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -26886,11 +26916,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -26919,11 +26949,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -26957,11 +26987,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -26969,12 +26999,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -26990,11 +27020,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -27002,7 +27032,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -27018,11 +27048,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -27051,11 +27081,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -27063,7 +27093,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -27085,11 +27115,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -27097,7 +27127,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -27123,11 +27153,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -27135,7 +27165,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -27158,11 +27188,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -27170,7 +27200,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -27187,11 +27217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -27199,7 +27229,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -27232,11 +27262,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -27244,7 +27274,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -27261,11 +27291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -27273,7 +27303,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -27296,11 +27326,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -27329,11 +27359,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -27362,11 +27392,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -27379,7 +27409,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -27400,11 +27430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -27417,7 +27447,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -27433,11 +27463,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -27461,11 +27491,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -27489,11 +27519,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -27511,7 +27541,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -27527,11 +27557,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -27561,11 +27591,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -27589,11 +27619,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -27611,11 +27641,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -27633,11 +27663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -27662,11 +27692,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -27690,11 +27720,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -27894,11 +27924,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -27923,11 +27953,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -28000,11 +28030,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -28078,11 +28108,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -28156,11 +28186,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -28211,11 +28241,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -28240,11 +28270,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -28262,11 +28292,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -28300,11 +28330,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -28317,7 +28347,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -28338,11 +28368,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -28355,7 +28385,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -28372,11 +28402,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -28400,11 +28430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -28433,11 +28463,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -28461,11 +28491,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -28483,7 +28513,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -28499,11 +28529,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -28528,11 +28558,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -28561,16 +28591,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -28600,11 +28630,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -28654,11 +28684,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -28676,11 +28706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -28698,11 +28728,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -28731,11 +28761,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -28765,11 +28795,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -28800,7 +28830,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridCellContentWrapperElement",
           "attributes": [
             {
@@ -28896,11 +28926,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -28919,11 +28949,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -28942,11 +28972,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -28965,11 +28995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -28988,11 +29018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -29011,11 +29041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -29034,11 +29064,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -29057,11 +29087,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -29080,11 +29110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -29103,11 +29133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -29126,11 +29156,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -29149,11 +29179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -29172,11 +29202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -29195,11 +29225,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -29218,11 +29248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -29241,11 +29271,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -29264,11 +29294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -29287,11 +29317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -29310,11 +29340,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -29333,11 +29363,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -29356,11 +29386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -29379,11 +29409,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -29402,11 +29432,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -29419,17 +29449,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -29448,11 +29478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -29895,11 +29925,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -30018,7 +30048,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -30135,11 +30165,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -30157,11 +30187,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -30490,11 +30520,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -30514,6 +30544,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -30528,11 +30563,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -30566,11 +30601,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -30604,11 +30639,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -30642,11 +30677,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -30659,7 +30694,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -30671,11 +30706,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -30705,11 +30740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -30733,11 +30768,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -30766,11 +30801,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -30795,11 +30830,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -30824,11 +30859,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -30862,11 +30897,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -30900,11 +30935,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -30934,11 +30969,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -30963,11 +30998,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -30992,11 +31027,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -31021,11 +31056,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -31050,11 +31085,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -31062,7 +31097,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -31094,11 +31129,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -31132,11 +31167,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -31160,11 +31195,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -31182,11 +31217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -31201,11 +31236,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -31223,11 +31258,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -31256,11 +31291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -31294,11 +31329,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -31306,12 +31341,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -31327,11 +31362,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -31339,7 +31374,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -31355,11 +31390,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -31388,11 +31423,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -31400,7 +31435,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -31422,11 +31457,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -31434,7 +31469,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -31460,11 +31495,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -31472,7 +31507,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -31495,11 +31530,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -31507,7 +31542,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -31524,11 +31559,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -31536,7 +31571,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -31569,11 +31604,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -31581,7 +31616,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -31598,11 +31633,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -31610,7 +31645,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -31633,11 +31668,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -31666,11 +31701,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -31699,11 +31734,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -31716,7 +31751,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -31737,11 +31772,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -31754,7 +31789,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -31770,11 +31805,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -31798,11 +31833,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -31826,11 +31861,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -31848,7 +31883,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -31864,11 +31899,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -31898,11 +31933,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -31926,11 +31961,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -31948,11 +31983,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -31970,11 +32005,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -31999,11 +32034,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -32027,11 +32062,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -32547,11 +32582,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -32576,11 +32611,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -32653,11 +32688,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -32731,11 +32766,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -32809,11 +32844,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -32864,11 +32899,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -32893,11 +32928,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -32915,11 +32950,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -32953,11 +32988,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -32970,7 +33005,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -32991,11 +33026,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -33008,7 +33043,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -33025,11 +33060,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -33053,11 +33088,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -33086,11 +33121,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -33114,11 +33149,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -33136,7 +33171,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -33152,11 +33187,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -33181,11 +33216,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -33214,16 +33249,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -33253,11 +33288,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -33307,11 +33342,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -33329,11 +33364,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -33351,11 +33386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -33384,11 +33419,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -33418,11 +33453,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -33453,7 +33488,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFilterEntityElement",
           "attributes": [
             {
@@ -33590,11 +33625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -33613,11 +33648,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -33636,11 +33671,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -33659,11 +33694,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -33682,11 +33717,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -33705,11 +33740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -33728,11 +33763,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -33751,11 +33786,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -33774,11 +33809,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -33797,11 +33832,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -33820,11 +33855,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -33843,11 +33878,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -33866,11 +33901,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -33889,11 +33924,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -33912,11 +33947,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -33935,11 +33970,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -33958,11 +33993,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -33981,11 +34016,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -34004,11 +34039,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -34027,11 +34062,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -34050,11 +34085,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -34073,11 +34108,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -34096,11 +34131,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -34113,17 +34148,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -34142,11 +34177,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -34341,11 +34376,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -34464,7 +34499,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -34598,11 +34633,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -34931,11 +34966,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -34955,6 +34990,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -34969,11 +35009,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -35007,11 +35047,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -35045,11 +35085,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -35083,11 +35123,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -35100,7 +35140,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -35112,11 +35152,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -35146,11 +35186,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -35174,11 +35214,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -35207,11 +35247,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -35236,11 +35276,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -35265,11 +35305,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -35303,11 +35343,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -35341,11 +35381,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -35375,11 +35415,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -35404,11 +35444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -35433,11 +35473,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -35462,11 +35502,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -35491,11 +35531,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -35503,7 +35543,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -35535,11 +35575,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -35573,11 +35613,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -35601,11 +35641,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -35623,11 +35663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -35642,11 +35682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -35664,11 +35704,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -35697,11 +35737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -35735,11 +35775,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -35747,12 +35787,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -35768,11 +35808,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -35780,7 +35820,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -35796,11 +35836,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -35829,11 +35869,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -35841,7 +35881,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -35863,11 +35903,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -35875,7 +35915,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -35901,11 +35941,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -35913,7 +35953,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -35936,11 +35976,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -35948,7 +35988,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -35965,11 +36005,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -35977,7 +36017,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -36010,11 +36050,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -36022,7 +36062,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -36039,11 +36079,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -36051,7 +36091,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -36074,11 +36114,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -36107,11 +36147,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -36140,11 +36180,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -36157,7 +36197,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -36178,11 +36218,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -36195,7 +36235,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -36211,11 +36251,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -36239,11 +36279,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -36267,11 +36307,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -36289,7 +36329,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -36305,11 +36345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -36339,11 +36379,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -36367,11 +36407,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -36389,11 +36429,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -36411,11 +36451,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -36440,11 +36480,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -36468,11 +36508,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -36684,11 +36724,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -36713,11 +36753,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -36790,11 +36830,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -36868,11 +36908,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -36946,11 +36986,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -37001,11 +37041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -37030,11 +37070,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -37052,11 +37092,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -37090,11 +37130,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -37107,7 +37147,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -37128,11 +37168,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -37145,7 +37185,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -37162,11 +37202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -37190,11 +37230,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -37223,11 +37263,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -37251,11 +37291,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -37273,7 +37313,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -37289,11 +37329,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -37318,11 +37358,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -37351,16 +37391,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -37390,11 +37430,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -37444,11 +37484,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -37466,11 +37506,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -37488,11 +37528,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -37521,11 +37561,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -37555,11 +37595,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -37590,7 +37630,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFilterSectionElement",
           "attributes": [
             {
@@ -37711,11 +37751,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -37734,11 +37774,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -37757,11 +37797,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -37780,11 +37820,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -37803,11 +37843,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -37826,11 +37866,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -37849,11 +37889,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -37872,11 +37912,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -37895,11 +37935,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -37918,11 +37958,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -37941,11 +37981,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -37964,11 +38004,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -37987,11 +38027,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -38010,11 +38050,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -38033,11 +38073,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -38056,11 +38096,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -38079,11 +38119,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -38102,11 +38142,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -38125,11 +38165,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -38148,11 +38188,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -38171,11 +38211,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -38194,11 +38234,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -38217,11 +38257,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -38234,17 +38274,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -38263,11 +38303,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -38425,11 +38465,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -38548,7 +38588,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -38665,11 +38705,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -38687,11 +38727,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -39020,11 +39060,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -39044,6 +39084,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -39058,11 +39103,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -39096,11 +39141,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -39134,11 +39179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -39172,11 +39217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -39189,7 +39234,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -39201,11 +39246,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -39235,11 +39280,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -39263,11 +39308,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -39296,11 +39341,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -39325,11 +39370,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -39354,11 +39399,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -39392,11 +39437,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -39430,11 +39475,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -39464,11 +39509,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -39493,11 +39538,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -39522,11 +39567,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -39551,11 +39596,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -39580,11 +39625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -39592,7 +39637,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -39624,11 +39669,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -39662,11 +39707,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -39690,11 +39735,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -39712,11 +39757,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -39731,11 +39776,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -39753,11 +39798,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -39786,11 +39831,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -39824,11 +39869,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -39836,12 +39881,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -39857,11 +39902,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -39869,7 +39914,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -39885,11 +39930,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -39918,11 +39963,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -39930,7 +39975,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -39952,11 +39997,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -39964,7 +40009,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -39990,11 +40035,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -40002,7 +40047,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -40025,11 +40070,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -40037,7 +40082,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -40054,11 +40099,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -40066,7 +40111,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -40099,11 +40144,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -40111,7 +40156,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -40128,11 +40173,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -40140,7 +40185,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -40163,11 +40208,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -40196,11 +40241,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -40229,11 +40274,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -40246,7 +40291,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -40267,11 +40312,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -40284,7 +40329,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -40300,11 +40345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -40328,11 +40373,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -40356,11 +40401,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -40378,7 +40423,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -40394,11 +40439,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -40428,11 +40473,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -40456,11 +40501,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -40478,11 +40523,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -40500,11 +40545,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -40529,11 +40574,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -40557,11 +40602,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -40733,11 +40778,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -40762,11 +40807,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -40839,11 +40884,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -40917,11 +40962,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -40995,11 +41040,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -41050,11 +41095,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -41079,11 +41124,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -41101,11 +41146,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -41139,11 +41184,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -41156,7 +41201,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -41177,11 +41222,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -41194,7 +41239,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -41211,11 +41256,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -41239,11 +41284,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -41272,11 +41317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -41300,11 +41345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -41322,7 +41367,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -41338,11 +41383,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -41367,11 +41412,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -41400,16 +41445,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -41439,11 +41484,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -41493,11 +41538,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -41515,11 +41560,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -41537,11 +41582,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -41570,11 +41615,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -41604,11 +41649,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -41639,7 +41684,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFilterElement",
           "attributes": [
             {
@@ -41789,11 +41834,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -41812,11 +41857,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -41835,11 +41880,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -41858,11 +41903,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -41881,11 +41926,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -41904,11 +41949,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -41927,11 +41972,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -41950,11 +41995,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -41973,11 +42018,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -41996,11 +42041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -42019,11 +42064,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -42042,11 +42087,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -42065,11 +42110,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -42088,11 +42133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -42111,11 +42156,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -42134,11 +42179,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -42157,11 +42202,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -42180,11 +42225,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -42203,11 +42248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -42226,11 +42271,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -42249,11 +42294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -42272,11 +42317,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -42295,11 +42340,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -42312,17 +42357,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -42341,11 +42386,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -42540,11 +42585,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -42663,7 +42708,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -42797,11 +42842,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -43130,11 +43175,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -43154,6 +43199,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -43168,11 +43218,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -43206,11 +43256,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -43244,11 +43294,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -43282,11 +43332,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -43299,7 +43349,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -43311,11 +43361,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -43345,11 +43395,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -43373,11 +43423,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -43406,11 +43456,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -43435,11 +43485,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -43464,11 +43514,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -43502,11 +43552,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -43540,11 +43590,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -43574,11 +43624,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -43603,11 +43653,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -43632,11 +43682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -43661,11 +43711,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -43690,11 +43740,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -43702,7 +43752,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -43734,11 +43784,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -43772,11 +43822,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -43800,11 +43850,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -43822,11 +43872,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -43841,11 +43891,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -43863,11 +43913,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -43896,11 +43946,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -43934,11 +43984,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -43946,12 +43996,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -43967,11 +44017,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -43979,7 +44029,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -43995,11 +44045,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -44028,11 +44078,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -44040,7 +44090,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -44062,11 +44112,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -44074,7 +44124,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -44100,11 +44150,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -44112,7 +44162,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -44135,11 +44185,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -44147,7 +44197,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -44164,11 +44214,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -44176,7 +44226,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -44209,11 +44259,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -44221,7 +44271,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -44238,11 +44288,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -44250,7 +44300,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -44273,11 +44323,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -44306,11 +44356,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -44339,11 +44389,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -44356,7 +44406,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -44377,11 +44427,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -44394,7 +44444,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -44410,11 +44460,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -44438,11 +44488,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -44466,11 +44516,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -44488,7 +44538,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -44504,11 +44554,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -44538,11 +44588,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -44566,11 +44616,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -44588,11 +44638,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -44610,11 +44660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -44639,11 +44689,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -44667,11 +44717,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -44850,11 +44900,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -44879,11 +44929,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -44956,11 +45006,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -45034,11 +45084,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -45112,11 +45162,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -45167,11 +45217,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -45196,11 +45246,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -45218,11 +45268,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -45256,11 +45306,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -45273,7 +45323,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -45294,11 +45344,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -45311,7 +45361,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -45328,11 +45378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -45356,11 +45406,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -45389,11 +45439,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -45417,11 +45467,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -45439,7 +45489,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -45455,11 +45505,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -45484,11 +45534,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -45517,16 +45567,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -45556,11 +45606,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -45610,11 +45660,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -45632,11 +45682,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -45654,11 +45704,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -45687,11 +45737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -45721,11 +45771,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -45756,7 +45806,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFiltersModalElement",
           "attributes": [
             {
@@ -45916,11 +45966,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -45939,11 +45989,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -45962,11 +46012,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -45985,11 +46035,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -46008,11 +46058,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -46031,11 +46081,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -46054,11 +46104,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -46077,11 +46127,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -46100,11 +46150,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -46123,11 +46173,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -46146,11 +46196,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -46169,11 +46219,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -46192,11 +46242,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -46215,11 +46265,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -46238,11 +46288,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -46261,11 +46311,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -46284,11 +46334,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -46307,11 +46357,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -46330,11 +46380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -46353,11 +46403,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -46376,11 +46426,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -46399,11 +46449,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -46422,11 +46472,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -46439,17 +46489,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -46468,11 +46518,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -46590,11 +46640,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -46713,7 +46763,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -46847,11 +46897,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -47180,11 +47230,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -47204,6 +47254,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -47218,11 +47273,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -47256,11 +47311,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -47294,11 +47349,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -47332,11 +47387,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -47349,7 +47404,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -47361,11 +47416,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -47395,11 +47450,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -47423,11 +47478,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -47456,11 +47511,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -47485,11 +47540,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -47514,11 +47569,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -47552,11 +47607,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -47590,11 +47645,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -47624,11 +47679,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -47653,11 +47708,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -47682,11 +47737,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -47711,11 +47766,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -47740,11 +47795,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -47752,7 +47807,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -47784,11 +47839,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -47822,11 +47877,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -47850,11 +47905,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -47872,11 +47927,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -47891,11 +47946,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -47913,11 +47968,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -47946,11 +48001,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -47984,11 +48039,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -47996,12 +48051,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -48017,11 +48072,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -48029,7 +48084,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -48045,11 +48100,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -48078,11 +48133,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -48090,7 +48145,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -48112,11 +48167,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -48124,7 +48179,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -48150,11 +48205,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -48162,7 +48217,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -48185,11 +48240,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -48197,7 +48252,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -48214,11 +48269,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -48226,7 +48281,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -48259,11 +48314,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -48271,7 +48326,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -48288,11 +48343,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -48300,7 +48355,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -48323,11 +48378,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -48356,11 +48411,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -48389,11 +48444,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -48406,7 +48461,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -48427,11 +48482,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -48444,7 +48499,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -48460,11 +48515,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -48488,11 +48543,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -48516,11 +48571,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -48538,7 +48593,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -48554,11 +48609,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -48588,11 +48643,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -48616,11 +48671,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -48638,11 +48693,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -48660,11 +48715,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -48689,11 +48744,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -48717,11 +48772,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -49164,11 +49219,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -49193,11 +49248,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -49270,11 +49325,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -49348,11 +49403,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -49426,11 +49481,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -49481,11 +49536,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -49510,11 +49565,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -49532,11 +49587,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -49570,11 +49625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -49587,7 +49642,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -49608,11 +49663,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -49625,7 +49680,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -49642,11 +49697,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -49670,11 +49725,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -49703,11 +49758,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -49731,11 +49786,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -49753,7 +49808,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -49769,11 +49824,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -49798,11 +49853,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -49831,16 +49886,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -49870,11 +49925,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -49924,11 +49979,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -49946,11 +50001,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -49968,11 +50023,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -50001,11 +50056,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -50035,11 +50090,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -50070,7 +50125,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridFiltersPreviewElement",
           "attributes": [
             {
@@ -52672,7 +52727,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.GridColumnElement",
           "name": "Predix.DataGridEditColumnElement",
           "attributes": [
             {
@@ -52866,11 +52921,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 8
                 },
                 "end": {
-                  "line": 1147,
+                  "line": 1148,
                   "column": 32
                 }
               },
@@ -52889,11 +52944,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 8
                 },
                 "end": {
-                  "line": 1149,
+                  "line": 1150,
                   "column": 34
                 }
               },
@@ -52912,11 +52967,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 8
                 },
                 "end": {
-                  "line": 1151,
+                  "line": 1152,
                   "column": 28
                 }
               },
@@ -52935,11 +52990,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 8
                 },
                 "end": {
-                  "line": 1153,
+                  "line": 1154,
                   "column": 31
                 }
               },
@@ -52958,11 +53013,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 8
                 },
                 "end": {
-                  "line": 1155,
+                  "line": 1156,
                   "column": 28
                 }
               },
@@ -52981,11 +53036,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 8
                 },
                 "end": {
-                  "line": 1157,
+                  "line": 1158,
                   "column": 35
                 }
               },
@@ -53004,11 +53059,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 8
                 },
                 "end": {
-                  "line": 1159,
+                  "line": 1160,
                   "column": 24
                 }
               },
@@ -53027,11 +53082,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 8
                 },
                 "end": {
-                  "line": 1161,
+                  "line": 1162,
                   "column": 24
                 }
               },
@@ -53050,11 +53105,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 8
                 },
                 "end": {
-                  "line": 1163,
+                  "line": 1164,
                   "column": 38
                 }
               },
@@ -53073,11 +53128,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 8
                 },
                 "end": {
-                  "line": 1165,
+                  "line": 1166,
                   "column": 20
                 }
               },
@@ -53096,11 +53151,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 8
                 },
                 "end": {
-                  "line": 1167,
+                  "line": 1168,
                   "column": 27
                 }
               },
@@ -53119,11 +53174,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 8
                 },
                 "end": {
-                  "line": 1169,
+                  "line": 1170,
                   "column": 23
                 }
               },
@@ -53142,11 +53197,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 8
                 },
                 "end": {
-                  "line": 1171,
+                  "line": 1172,
                   "column": 30
                 }
               },
@@ -53165,11 +53220,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 8
                 },
                 "end": {
-                  "line": 1173,
+                  "line": 1174,
                   "column": 30
                 }
               },
@@ -53188,11 +53243,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 8
                 },
                 "end": {
-                  "line": 1175,
+                  "line": 1176,
                   "column": 29
                 }
               },
@@ -53211,11 +53266,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 8
                 },
                 "end": {
-                  "line": 1177,
+                  "line": 1178,
                   "column": 32
                 }
               },
@@ -53234,11 +53289,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 8
                 },
                 "end": {
-                  "line": 1179,
+                  "line": 1180,
                   "column": 30
                 }
               },
@@ -53257,11 +53312,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 8
                 },
                 "end": {
-                  "line": 1181,
+                  "line": 1182,
                   "column": 24
                 }
               },
@@ -53280,11 +53335,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 8
                 },
                 "end": {
-                  "line": 1183,
+                  "line": 1184,
                   "column": 28
                 }
               },
@@ -53303,11 +53358,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 435,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 435,
                   "column": 23
                 }
               },
@@ -53326,11 +53381,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 423,
+                  "line": 437,
                   "column": 8
                 },
                 "end": {
-                  "line": 423,
+                  "line": 437,
                   "column": 25
                 }
               },
@@ -53349,11 +53404,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 439,
                   "column": 8
                 },
                 "end": {
-                  "line": 425,
+                  "line": 439,
                   "column": 22
                 }
               },
@@ -53372,11 +53427,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 427,
+                  "line": 441,
                   "column": 8
                 },
                 "end": {
-                  "line": 427,
+                  "line": 441,
                   "column": 24
                 }
               },
@@ -53389,17 +53444,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 429,
+                  "line": 443,
                   "column": 8
                 },
                 "end": {
-                  "line": 429,
+                  "line": 443,
                   "column": 18
                 }
               },
@@ -53418,11 +53473,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 431,
+                  "line": 445,
                   "column": 8
                 },
                 "end": {
-                  "line": 431,
+                  "line": 445,
                   "column": 15
                 }
               },
@@ -53582,11 +53637,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2423,
+                  "line": 2424,
                   "column": 6
                 },
                 "end": {
-                  "line": 2448,
+                  "line": 2449,
                   "column": 7
                 }
               },
@@ -53705,7 +53760,7 @@
               "params": [
                 {
                   "name": "node",
-                  "type": "Node",
+                  "type": "!Node",
                   "description": "Node to remove event listener from"
                 },
                 {
@@ -53822,11 +53877,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 540,
+                  "line": 553,
                   "column": 6
                 },
                 "end": {
-                  "line": 546,
+                  "line": 559,
                   "column": 7
                 }
               },
@@ -53844,11 +53899,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 460,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 493,
                   "column": 7
                 }
               },
@@ -54177,11 +54232,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 412,
+                  "line": 413,
                   "column": 8
                 },
                 "end": {
-                  "line": 419,
+                  "line": 420,
                   "column": 9
                 }
               },
@@ -54201,6 +54256,11 @@
                   "name": "value",
                   "type": "?string",
                   "description": "New attribute value"
+                },
+                {
+                  "name": "namespace",
+                  "type": "?string",
+                  "description": "Attribute namespace."
                 }
               ],
               "return": {
@@ -54215,11 +54275,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 434,
                   "column": 8
                 },
                 "end": {
-                  "line": 440,
+                  "line": 441,
                   "column": 9
                 }
               },
@@ -54253,11 +54313,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 452,
+                  "line": 453,
                   "column": 8
                 },
                 "end": {
-                  "line": 458,
+                  "line": 459,
                   "column": 9
                 }
               },
@@ -54291,11 +54351,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 473,
+                  "line": 474,
                   "column": 8
                 },
                 "end": {
-                  "line": 480,
+                  "line": 481,
                   "column": 9
                 }
               },
@@ -54329,11 +54389,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 493,
+                  "line": 494,
                   "column": 8
                 },
                 "end": {
-                  "line": 500,
+                  "line": 501,
                   "column": 9
                 }
               },
@@ -54346,7 +54406,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided\nproperty  value."
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
@@ -54358,11 +54418,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 514,
+                  "line": 515,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 524,
                   "column": 9
                 }
               },
@@ -54392,11 +54452,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1217,
+                  "line": 1218,
                   "column": 6
                 },
                 "end": {
-                  "line": 1221,
+                  "line": 1222,
                   "column": 7
                 }
               },
@@ -54420,11 +54480,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 193,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 198,
                   "column": 7
                 }
               },
@@ -54453,11 +54513,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 300,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 302,
                   "column": 7
                 }
               },
@@ -54482,11 +54542,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 311,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 313,
                   "column": 7
                 }
               },
@@ -54511,11 +54571,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1255,
+                  "line": 1256,
                   "column": 6
                 },
                 "end": {
-                  "line": 1263,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -54549,11 +54609,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1273,
+                  "line": 1274,
                   "column": 6
                 },
                 "end": {
-                  "line": 1279,
+                  "line": 1280,
                   "column": 7
                 }
               },
@@ -54587,11 +54647,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1290,
+                  "line": 1291,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1294,
                   "column": 7
                 }
               },
@@ -54621,11 +54681,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1304,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1306,
                   "column": 7
                 }
               },
@@ -54650,11 +54710,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1315,
+                  "line": 1316,
                   "column": 6
                 },
                 "end": {
-                  "line": 1317,
+                  "line": 1318,
                   "column": 7
                 }
               },
@@ -54679,11 +54739,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1327,
+                  "line": 1328,
                   "column": 6
                 },
                 "end": {
-                  "line": 1329,
+                  "line": 1330,
                   "column": 7
                 }
               },
@@ -54708,11 +54768,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1339,
+                  "line": 1340,
                   "column": 6
                 },
                 "end": {
-                  "line": 1341,
+                  "line": 1342,
                   "column": 7
                 }
               },
@@ -54737,11 +54797,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1373,
+                  "line": 1374,
                   "column": 6
                 },
                 "end": {
-                  "line": 1405,
+                  "line": 1406,
                   "column": 7
                 }
               },
@@ -54749,7 +54809,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -54781,11 +54841,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1428,
+                  "line": 1429,
                   "column": 6
                 },
                 "end": {
-                  "line": 1436,
+                  "line": 1437,
                   "column": 7
                 }
               },
@@ -54819,11 +54879,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1543,
+                  "line": 1544,
                   "column": 6
                 },
                 "end": {
-                  "line": 1548,
+                  "line": 1549,
                   "column": 7
                 }
               },
@@ -54847,11 +54907,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1569,
+                  "line": 1570,
                   "column": 6
                 },
                 "end": {
-                  "line": 1580,
+                  "line": 1581,
                   "column": 7
                 }
               },
@@ -54869,11 +54929,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1594,
+                  "line": 1595,
                   "column": 6
                 },
                 "end": {
-                  "line": 1607,
+                  "line": 1608,
                   "column": 7
                 }
               },
@@ -54888,11 +54948,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 558,
+                  "line": 571,
                   "column": 6
                 },
                 "end": {
-                  "line": 567,
+                  "line": 580,
                   "column": 7
                 }
               },
@@ -54910,11 +54970,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1636,
+                  "line": 1637,
                   "column": 6
                 },
                 "end": {
-                  "line": 1647,
+                  "line": 1648,
                   "column": 7
                 }
               },
@@ -54943,11 +55003,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1734,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1744,
+                  "line": 1745,
                   "column": 7
                 }
               },
@@ -54981,11 +55041,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1755,
+                  "line": 1756,
                   "column": 6
                 },
                 "end": {
-                  "line": 1760,
+                  "line": 1761,
                   "column": 7
                 }
               },
@@ -54993,12 +55053,12 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
@@ -55014,11 +55074,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1772,
+                  "line": 1773,
                   "column": 6
                 },
                 "end": {
-                  "line": 1777,
+                  "line": 1778,
                   "column": 7
                 }
               },
@@ -55026,7 +55086,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
@@ -55042,11 +55102,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1809,
+                  "line": 1810,
                   "column": 6
                 },
                 "end": {
-                  "line": 1813,
+                  "line": 1814,
                   "column": 7
                 }
               },
@@ -55075,11 +55135,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1834,
+                  "line": 1835,
                   "column": 6
                 },
                 "end": {
-                  "line": 1836,
+                  "line": 1837,
                   "column": 7
                 }
               },
@@ -55087,7 +55147,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -55109,11 +55169,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1859,
+                  "line": 1860,
                   "column": 6
                 },
                 "end": {
-                  "line": 1869,
+                  "line": 1870,
                   "column": 7
                 }
               },
@@ -55121,7 +55181,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -55147,11 +55207,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1885,
+                  "line": 1886,
                   "column": 6
                 },
                 "end": {
-                  "line": 1894,
+                  "line": 1895,
                   "column": 7
                 }
               },
@@ -55159,7 +55219,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -55182,11 +55242,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1909,
+                  "line": 1910,
                   "column": 6
                 },
                 "end": {
-                  "line": 1918,
+                  "line": 1919,
                   "column": 7
                 }
               },
@@ -55194,7 +55254,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -55211,11 +55271,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1937,
+                  "line": 1938,
                   "column": 6
                 },
                 "end": {
-                  "line": 1974,
+                  "line": 1975,
                   "column": 7
                 }
               },
@@ -55223,7 +55283,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -55256,11 +55316,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1989,
+                  "line": 1990,
                   "column": 6
                 },
                 "end": {
-                  "line": 1998,
+                  "line": 1999,
                   "column": 7
                 }
               },
@@ -55268,7 +55328,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -55285,11 +55345,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2014,
+                  "line": 2015,
                   "column": 6
                 },
                 "end": {
-                  "line": 2022,
+                  "line": 2023,
                   "column": 7
                 }
               },
@@ -55297,7 +55357,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -55320,11 +55380,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2037,
+                  "line": 2038,
                   "column": 6
                 },
                 "end": {
-                  "line": 2054,
+                  "line": 2055,
                   "column": 7
                 }
               },
@@ -55353,11 +55413,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2067,
+                  "line": 2068,
                   "column": 6
                 },
                 "end": {
-                  "line": 2074,
+                  "line": 2075,
                   "column": 7
                 }
               },
@@ -55386,11 +55446,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2088,
+                  "line": 2089,
                   "column": 6
                 },
                 "end": {
-                  "line": 2098,
+                  "line": 2099,
                   "column": 7
                 }
               },
@@ -55403,7 +55463,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -55424,11 +55484,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2111,
+                  "line": 2112,
                   "column": 6
                 },
                 "end": {
-                  "line": 2117,
+                  "line": 2118,
                   "column": 7
                 }
               },
@@ -55441,7 +55501,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -55457,11 +55517,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2128,
+                  "line": 2129,
                   "column": 6
                 },
                 "end": {
-                  "line": 2136,
+                  "line": 2137,
                   "column": 7
                 }
               },
@@ -55485,11 +55545,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2147,
+                  "line": 2148,
                   "column": 6
                 },
                 "end": {
-                  "line": 2160,
+                  "line": 2161,
                   "column": 7
                 }
               },
@@ -55513,11 +55573,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2174,
+                  "line": 2175,
                   "column": 6
                 },
                 "end": {
-                  "line": 2180,
+                  "line": 2181,
                   "column": 7
                 }
               },
@@ -55535,7 +55595,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
@@ -55551,11 +55611,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2357,
+                  "line": 2358,
                   "column": 6
                 },
                 "end": {
-                  "line": 2380,
+                  "line": 2381,
                   "column": 7
                 }
               },
@@ -55585,11 +55645,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2459,
+                  "line": 2460,
                   "column": 6
                 },
                 "end": {
-                  "line": 2480,
+                  "line": 2481,
                   "column": 7
                 }
               },
@@ -55613,11 +55673,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 540,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 545,
                   "column": 7
                 }
               },
@@ -55635,11 +55695,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 215,
+                  "line": 216,
                   "column": 6
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 7
                 }
               },
@@ -55657,11 +55717,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 581,
+                  "line": 594,
                   "column": 6
                 },
                 "end": {
-                  "line": 597,
+                  "line": 610,
                   "column": 7
                 }
               },
@@ -55686,11 +55746,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 620,
+                  "line": 633,
                   "column": 6
                 },
                 "end": {
-                  "line": 624,
+                  "line": 637,
                   "column": 7
                 }
               },
@@ -55714,11 +55774,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 641,
+                  "line": 654,
                   "column": 6
                 },
                 "end": {
-                  "line": 646,
+                  "line": 659,
                   "column": 7
                 }
               },
@@ -56059,11 +56119,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 657,
+                  "line": 670,
                   "column": 6
                 },
                 "end": {
-                  "line": 660,
+                  "line": 673,
                   "column": 7
                 }
               },
@@ -56088,11 +56148,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2499,
+                  "line": 2500,
                   "column": 6
                 },
                 "end": {
-                  "line": 2513,
+                  "line": 2514,
                   "column": 7
                 }
               },
@@ -56165,11 +56225,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2591,
+                  "line": 2592,
                   "column": 6
                 },
                 "end": {
-                  "line": 2601,
+                  "line": 2602,
                   "column": 7
                 }
               },
@@ -56243,11 +56303,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2534,
+                  "line": 2535,
                   "column": 6
                 },
                 "end": {
-                  "line": 2575,
+                  "line": 2576,
                   "column": 7
                 }
               },
@@ -56321,11 +56381,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 325,
+                  "line": 326,
                   "column": 7
                 },
                 "end": {
-                  "line": 329,
+                  "line": 330,
                   "column": 7
                 }
               },
@@ -56376,11 +56436,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 180,
+                  "line": 181,
                   "column": 6
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 7
                 }
               },
@@ -56405,11 +56465,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 7
                 }
               },
@@ -56427,11 +56487,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2220,
+                  "line": 2221,
                   "column": 6
                 },
                 "end": {
-                  "line": 2222,
+                  "line": 2223,
                   "column": 7
                 }
               },
@@ -56465,11 +56525,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2234,
+                  "line": 2235,
                   "column": 6
                 },
                 "end": {
-                  "line": 2236,
+                  "line": 2237,
                   "column": 7
                 }
               },
@@ -56482,7 +56542,7 @@
                 },
                 {
                   "name": "method",
-                  "type": "(string|function (*, *))",
+                  "type": "(string | function (*, *))",
                   "description": "Function or name of observer method to call"
                 },
                 {
@@ -56503,11 +56563,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2251,
+                  "line": 2252,
                   "column": 6
                 },
                 "end": {
-                  "line": 2253,
+                  "line": 2254,
                   "column": 7
                 }
               },
@@ -56520,7 +56580,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating"
                 }
               ],
@@ -56537,11 +56597,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2263,
+                  "line": 2264,
                   "column": 6
                 },
                 "end": {
-                  "line": 2265,
+                  "line": 2266,
                   "column": 7
                 }
               },
@@ -56565,11 +56625,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2283,
+                  "line": 2284,
                   "column": 6
                 },
                 "end": {
-                  "line": 2285,
+                  "line": 2286,
                   "column": 7
                 }
               },
@@ -56598,11 +56658,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2295,
+                  "line": 2296,
                   "column": 6
                 },
                 "end": {
-                  "line": 2297,
+                  "line": 2298,
                   "column": 7
                 }
               },
@@ -56626,11 +56686,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2313,
+                  "line": 2314,
                   "column": 6
                 },
                 "end": {
-                  "line": 2315,
+                  "line": 2316,
                   "column": 7
                 }
               },
@@ -56648,7 +56708,7 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
@@ -56664,11 +56724,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2329,
+                  "line": 2330,
                   "column": 6
                 },
                 "end": {
-                  "line": 2331,
+                  "line": 2332,
                   "column": 7
                 }
               },
@@ -56693,11 +56753,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2396,
                   "column": 6
                 },
                 "end": {
-                  "line": 2401,
+                  "line": 2402,
                   "column": 7
                 }
               },
@@ -56726,16 +56786,16 @@
             },
             {
               "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2636,
+                  "line": 2648,
                   "column": 6
                 },
                 "end": {
-                  "line": 2701,
+                  "line": 2713,
                   "column": 7
                 }
               },
@@ -56765,11 +56825,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2717,
+                  "line": 2729,
                   "column": 6
                 },
                 "end": {
-                  "line": 2734,
+                  "line": 2746,
                   "column": 7
                 }
               },
@@ -56819,11 +56879,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 128,
+                  "line": 129,
                   "column": 6
                 },
                 "end": {
-                  "line": 137,
+                  "line": 138,
                   "column": 7
                 }
               },
@@ -56841,11 +56901,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 294,
                   "column": 5
                 },
                 "end": {
-                  "line": 316,
+                  "line": 317,
                   "column": 7
                 }
               },
@@ -56863,11 +56923,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 342,
+                  "line": 343,
                   "column": 6
                 },
                 "end": {
-                  "line": 347,
+                  "line": 348,
                   "column": 7
                 }
               },
@@ -56896,11 +56956,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 490,
+                  "line": 503,
                   "column": 6
                 },
                 "end": {
-                  "line": 492,
+                  "line": 505,
                   "column": 7
                 }
               },
@@ -56930,11 +56990,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 503,
+                  "line": 516,
                   "column": 6
                 },
                 "end": {
-                  "line": 514,
+                  "line": 527,
                   "column": 7
                 }
               },
@@ -56965,7 +57025,7 @@
             }
           },
           "privacy": "public",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Predix.DataGridNavigationElement",
           "attributes": [
             {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -1480,7 +1480,7 @@ limitations under the License.
         _handleSelectItem(item) {
           if (!this._vaadinGrid._isSelected(item)) {
             if (!this._isMultiSelect()) {
-              this._vaadinGrid.selectedItems = [];
+              this._vaadinGrid.pop('selectedItems');
             }
             this._vaadinGrid.push('selectedItems', item);
           }


### PR DESCRIPTION
When single-select is being used, the removal of the item from the selectedItems list is triggering the same event logic as when new data is set (clear selectedItems).

This differs from the removal of the item in multi-select, where the deselected item is popped from the list, triggering the splice event flow.

By changing the single-select removal to use the splice event flow instead of the clear event flow, we make the events across single-select and multi-select consistent. Using the selected-item-changed event becomes more consistent across these two selection modes.