### PR TITLE
missing bindings for i18n

### DIFF
--- a/px-data-grid-navigation.html
+++ b/px-data-grid-navigation.html
@@ -46,7 +46,7 @@ limitations under the License.
           <div class="row-counts">
             <span class="current-rows">
               [[_getItemsRangeStr(currentPage, pageSize, totalItemCount)]]
-            </span> [[_getOfStr(totalItemCount)]]
+            </span> [[_getOfStr(totalItemCount, localize)]]
           </div>
 
           <!-- page selection list -->

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -48,6 +48,7 @@ limitations under the License.
       column-reordering-allowed="{{columnReorderingAllowed}}"
       hide-action-menu="{{hideActionMenu}}"
       language="{{language}}"
+      resources="{{resources}}"
       auto-filter="{{autoFilter}}"
       grid-height="{{gridHeight}}"
       item-id-path="{{itemIdPath}}"


### PR DESCRIPTION
Some missing data bindings for a proper i18n: 
- `resources` not bound from parent `px-data-grid-paginated` to parent `px-data-grid`
- `localize` missing in a `px-data-grid-navigation` binding