### PR TITLE
Disable column options hide button per column.

### DIFF
--- a/px-data-grid-header-cell.html
+++ b/px-data-grid-header-cell.html
@@ -267,7 +267,8 @@ limitations under the License.
           if (this._column && this._column._grid && this._column._grid._pxDataGrid) {
             const pxDataGrid = this._column._grid._pxDataGrid;
             const groupedByThis = pxDataGrid._groupByColumn == this._column;
-            return !groupedByThis && pxDataGrid.getVisibleColumns().length > 1;
+            const disableHide = this._column.disableHide;
+            return !disableHide && !groupedByThis && pxDataGrid.getVisibleColumns().length > 1;
           } else {
             console.warn('Failed to resolve if column can be hidden');
             return true;

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -146,6 +146,7 @@ limitations under the License.
           name="[[column.name]]"
           path="[[column.path]]"
           hidden="[[column.hidden]]"
+          disable-hide="[[column.disableHide]]"
           localize="[[_boundedLocalize]]"
           type="[[column.type]]"
           frozen="[[_undefinedToFalse(column.frozen)]]"


### PR DESCRIPTION
Addresses issues #783 and #304.

Makes the `Hide Column` action in the Column Action menu able to be removed per column.
Motivation for this feature is the case when the Column Filter menu is disabled, if a user then hides a column through the Column Action menu then there is no way to unhide it.